### PR TITLE
New feature: ShutdownInterceptor enables shutdown the router via HTTP-request

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+# any VIM swap file
+.*.swp
+_*.swp
+
 # /
 /target
 /membrane.log
@@ -20,6 +24,8 @@
 /cli/memrouter.log
 /cli/membrane.log
 /cli/derby.log
+/cli/executable.ps1
+/cli/log.csv
 
 # /cli/examples/router/custom-interceptor/
 /cli/examples/router/custom-interceptor/dist

--- a/cli/examples/shutdown/README.txt
+++ b/cli/examples/shutdown/README.txt
@@ -1,0 +1,31 @@
+SHUTDOWN INTERCEPTOR
+
+Using the ShutdownInterceptor, Membrane Monitor and Service Proxy can shutdown on HTTP request.
+
+RUNNING THE EXAMPLE
+
+In this example we will stop Membrane Service proxy via HTTP request.
+
+To run the example execute the following steps:
+
+1. Go to the examples/shutdown directory.
+
+2. Execute service-proxy.bat
+
+3. Send POST to the URL http://localhost:2000/shutdown with "some text including 'secret code' in the content" 
+
+4. Take a look at the output of the console.
+
+5. service-proxy.bat should end
+
+
+Troubleshooting:
+
+If Membrane does not generate any ouput after loading an URL, it is possible that your browser has already cached the ressource. 
+
+Shortcuts for the different browsers:
+
+Safari: ALT + click reload or CMD + SHIFT + R while using a mac
+Firefox: SHIFT + click reload
+Chrome: SHIFT + F5 or CONTROL + F5
+IE: CONTROL + F5

--- a/cli/examples/shutdown/proxies.xml
+++ b/cli/examples/shutdown/proxies.xml
@@ -8,6 +8,9 @@
         <serviceProxy name="predic8.com" port="2000" method="POST" ip="127.0.0.1" >
             <!-- Accessible only via localhost interface ( ip="127.0.0.1" ).
                  Be careful, if you set up shutdown interceptor to public IP-address.
+                 Be carefull about https://github.com/membrane/service-proxy/issues/170
+                 Maybe this could be better in case of more interfaces: 
+                 <serviceProxy name="predic8.com" port="2000" method="POST" host="localhost" >
             -->
             <!-- Only for specific path.
                  Be careful, putting secret code to URL is not good idea, URLs are usually logged. -->

--- a/cli/examples/shutdown/proxies.xml
+++ b/cli/examples/shutdown/proxies.xml
@@ -5,30 +5,28 @@
                         http://membrane-soa.org/proxies/1/ http://membrane-soa.org/schemas/proxies-1.xsd">
 
     <router>
-        <serviceProxy name="predic8.com" port="2000" ip="127.0.0.1">
+        <serviceProxy name="predic8.com" port="2000" method="POST" ip="127.0.0.1" >
             <!-- Accessible only via localhost interface ( ip="127.0.0.1" ).
                  Be careful, if you set up shutdown interceptor to public IP-address.
             -->
             <!-- Only for specific path.
                  Be careful, putting secret code to URL is not good idea, URLs are usually logged. -->
             <path>/shutdown</path>
-            
-            <!-- !!! don't forget set up security !!! This example is without security. -->
 
-            <!-- The simplest case : any HTTP method (GET/POST/PUT/HEAD/DELETE/TRACE/CONNECT/OPTIONS) to shutdown.
-            <shutdown />
-            -->
+            <!-- !!! don't forget set up security !!! --> 
+            <basicAuthentication>
+                <user name="abc" password="def"/>
+            </basicAuthentication> 
 
-            <!-- only PUT method, other methods (GET/POST/HEAD/DELETE/TRACE/CONNECT/OPTIONS) are ignored
-            <shutdown httpMethod="PUT"/>
-            -->
-
-            <!-- only POST method where body contains "'secret code'" ( bodyContent is valid only for POST and PUT) -->
-            <shutdown httpMethod="POST" bodyContent="'secret code'"/>
-
-            <!-- only DELETE method, bodyContent is not significant (bodyContent is valid only for POST and PUT )
-            <shutdown httpMethod="DELETE" bodyContent="anything, because it's not validated"/>
-            -->
+            <if test="exc.request.bodyAsStringDecoded.contains('secret code')">
+                <shutdown />
+            </if>
+            <!-- else / default -->
+            <groovy>
+                exc.setResponse(
+                    Response.badRequest().contentType("text/plain").body("Body doesn't contain 'secret code'").build())
+                RETURN
+            </groovy>
         </serviceProxy>
     </router>
 

--- a/cli/examples/shutdown/proxies.xml
+++ b/cli/examples/shutdown/proxies.xml
@@ -1,0 +1,35 @@
+<spring:beans xmlns="http://membrane-soa.org/proxies/1/"
+    xmlns:spring="http://www.springframework.org/schema/beans"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+                        http://membrane-soa.org/proxies/1/ http://membrane-soa.org/schemas/proxies-1.xsd">
+
+    <router>
+        <serviceProxy name="predic8.com" port="2000" ip="127.0.0.1">
+            <!-- Accessible only via localhost interface ( ip="127.0.0.1" ).
+                 Be careful, if you set up shutdown interceptor to public IP-address.
+            -->
+            <!-- Only for specific path.
+                 Be careful, putting secret code to URL is not good idea, URLs are usually logged. -->
+            <path>/shutdown</path>
+            
+            <!-- !!! don't forget set up security !!! This example is without security. -->
+
+            <!-- The simplest case : any HTTP method (GET/POST/PUT/HEAD/DELETE/TRACE/CONNECT/OPTIONS) to shutdown.
+            <shutdown />
+            -->
+
+            <!-- only PUT method, other methods (GET/POST/HEAD/DELETE/TRACE/CONNECT/OPTIONS) are ignored
+            <shutdown httpMethod="PUT"/>
+            -->
+
+            <!-- only POST method where body contains "'secret code'" ( bodyContent is valid only for POST and PUT) -->
+            <shutdown httpMethod="POST" bodyContent="'secret code'"/>
+
+            <!-- only DELETE method, bodyContent is not significant (bodyContent is valid only for POST and PUT )
+            <shutdown httpMethod="DELETE" bodyContent="anything, because it's not validated"/>
+            -->
+        </serviceProxy>
+    </router>
+
+</spring:beans>

--- a/cli/examples/shutdown/service-proxy.bat
+++ b/cli/examples/shutdown/service-proxy.bat
@@ -1,0 +1,18 @@
+@echo off
+if not "%MEMBRANE_HOME%" == "" goto homeSet
+set "MEMBRANE_HOME=%cd%\..\.."
+echo "%MEMBRANE_HOME%"
+if exist "%MEMBRANE_HOME%\service-proxy.bat" goto homeOk
+
+:homeSet
+if exist "%MEMBRANE_HOME%\service-proxy.bat" goto homeOk
+echo Please set the MEMBRANE_HOME environment variable to point to
+echo the directory where you have extracted the Membrane software.
+exit
+
+:homeOk
+set "CLASSPATH=%MEMBRANE_HOME%"
+set "CLASSPATH=%MEMBRANE_HOME%/conf"
+set "CLASSPATH=%CLASSPATH%;%MEMBRANE_HOME%/starter.jar"
+echo Membrane Router running...
+java  -classpath "%CLASSPATH%" com.predic8.membrane.core.Starter -c proxies.xml

--- a/cli/examples/shutdown/service-proxy.sh
+++ b/cli/examples/shutdown/service-proxy.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+homeSet() {
+ echo "MEMBRANE_HOME variable is now set"
+ CLASSPATH="$MEMBRANE_HOME/conf"
+ CLASSPATH="$CLASSPATH:$MEMBRANE_HOME/starter.jar"
+ export CLASSPATH
+ echo Membrane Router running...
+ java  -classpath "$CLASSPATH" com.predic8.membrane.core.Starter -c proxies.xml
+ 
+}
+
+terminate() {
+	echo "Starting of Membrane Router failed."
+	echo "Please execute this script from the MEMBRANE_HOME/examples/shutdown directory"
+	
+}
+
+homeNotSet() {
+  echo "MEMBRANE_HOME variable is not set"
+
+  if [ -f  "`pwd`/../../starter.jar" ]
+    then 
+    	export MEMBRANE_HOME="`pwd`/../.."
+    	homeSet	
+    else
+    	terminate    
+  fi 
+}
+
+
+if  [ "$MEMBRANE_HOME" ]  
+	then homeSet
+	else homeNotSet
+fi
+

--- a/cli/src/test/java/com/predic8/membrane/examples/tests/ShutdownTest.java
+++ b/cli/src/test/java/com/predic8/membrane/examples/tests/ShutdownTest.java
@@ -33,6 +33,7 @@ public class ShutdownTest extends DistributionExtractingTestcase {
 		        // .withWatcher(new com.predic8.membrane.examples.util.ConsoleLogger())
 		        .script("service-proxy").waitForMembrane().start();
 		try {
+		    AssertUtils.setupHTTPAuthentication("localhost",2000,"abc","def");
 			AssertUtils.getAndAssert(400, "http://localhost:2000/shutdown");
 			AssertUtils.postAndAssert(400, "http://localhost:2000/shutdown", "without code");
 			AssertUtils.postAndAssert200("http://localhost:2000/shutdown", "This is body with 'secret code' inside");

--- a/cli/src/test/java/com/predic8/membrane/examples/tests/ShutdownTest.java
+++ b/cli/src/test/java/com/predic8/membrane/examples/tests/ShutdownTest.java
@@ -1,0 +1,45 @@
+/* Copyright 2012 predic8 GmbH, www.predic8.com
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
+package com.predic8.membrane.examples.tests;
+
+import java.io.IOException;
+
+import org.junit.Test;
+
+import com.predic8.membrane.examples.DistributionExtractingTestcase;
+import com.predic8.membrane.examples.Process2;
+import com.predic8.membrane.test.AssertUtils;
+
+import static org.junit.Assert.*;
+
+@SuppressWarnings("javadoc")
+public class ShutdownTest extends DistributionExtractingTestcase {
+
+	@Test
+	public void test() throws IOException, InterruptedException {
+		Process2 sl = new Process2.Builder().in(getExampleDir("shutdown"))
+		        // .withWatcher(new com.predic8.membrane.examples.util.ConsoleLogger())
+		        .script("service-proxy").waitForMembrane().start();
+		try {
+			AssertUtils.getAndAssert(400, "http://localhost:2000/shutdown");
+			AssertUtils.postAndAssert(400, "http://localhost:2000/shutdown", "without code");
+			AssertUtils.postAndAssert200("http://localhost:2000/shutdown", "This is body with 'secret code' inside");
+			assertEquals(0,sl.waitFor(10000));
+		} finally {
+			sl.killScript();
+		}
+	}
+
+}

--- a/core/src/main/java/com/predic8/membrane/core/RouterCLI.java
+++ b/core/src/main/java/com/predic8/membrane/core/RouterCLI.java
@@ -52,11 +52,7 @@ public class RouterCLI {
 	}
 
 	private synchronized void waitForever() {
-		try {
-			wait();
-		} catch (InterruptedException e) {
-			// do nothing
-		}
+	    // DONOTHING, Router has own thread ( Spring HotDeploymentThread )
 	}
 	
 	private static String getRulesFile(MembraneCommandLine line) {

--- a/core/src/main/java/com/predic8/membrane/core/interceptor/shutdown/ShutdownInterceptor.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/shutdown/ShutdownInterceptor.java
@@ -1,0 +1,106 @@
+/* Copyright 2009, 2012 predic8 GmbH, www.predic8.com
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+package com.predic8.membrane.core.interceptor.shutdown;
+
+import com.predic8.membrane.annot.MCAttribute;
+import com.predic8.membrane.annot.MCElement;
+import com.predic8.membrane.core.exchange.Exchange;
+import com.predic8.membrane.core.http.Request;
+import com.predic8.membrane.core.http.Response;
+import com.predic8.membrane.core.interceptor.AbstractInterceptor;
+import com.predic8.membrane.core.interceptor.Outcome;
+
+/**
+ * @description Shutdown interceptor.
+ * @explanation Adds the ability to shutdown main router thread via an HTTP request.
+ *              Don't forget to setup security for this interceptor.
+ * @topic 4. Interceptors/Features
+ */
+@MCElement(name="shutdown")
+public class ShutdownInterceptor extends AbstractInterceptor {
+    
+    private String httpMethod;
+    private String bodyContent;
+    
+    @Override
+    public Outcome handleRequest(Exchange exc) throws Exception {
+        if (httpMethod == null // don't check method 
+                || verifyMethodAndContent(exc.getRequest())) {
+            exc.setResponse(Response.ok().contentType("text/plain").body("OK").build());
+            new Thread(new Runnable() {
+                @Override
+                public void run() {
+                    try {
+                        Thread.sleep(100); // Wait a moment to finish this request.
+                    } catch (InterruptedException e) {
+                        // DONOTHING
+                    }
+                    getRouter().stop(); // stop the router
+                }
+            }).start();
+        } else {
+            exc.setResponse(
+                    Response.badRequest().contentType("text/plain").body("Invalid request to shutdown").build());
+        }
+        return Outcome.RETURN;
+    }
+
+    private boolean verifyMethodAndContent(Request request) {
+        boolean ret = false;
+        final String rmethod = request.getMethod();
+        if (httpMethod.equals(rmethod)) {
+            ret = true;
+            if (bodyContent != null && (Request.METHOD_POST.equals(rmethod) || Request.METHOD_PUT.equals(rmethod))) {
+                final String rbody = request.getBodyAsStringDecoded();
+                ret = rbody !=null && rbody.contains(bodyContent);
+            }
+        }
+        return ret;
+    }
+
+    /**
+     * @return the HTTP method
+     */
+    public String getHttpMethod() {
+        return httpMethod;
+    }
+
+    /**
+     * @description required HTTP method to shutdown process. If not set, any method is allowed. 
+     * @param httpMethod HTTP-method ( GET/POST/HEAD/DELETE/PUT/TRACE/CONNECT/OPTIONS )
+     */
+    @MCAttribute
+    public void setHttpMethod(String httpMethod) {
+        this.httpMethod = httpMethod;
+    }
+
+    /**
+     * @return the bodyContent
+     */
+    public String getBodyContent() {
+        return bodyContent;
+    }
+
+    /**
+     * @description string which should POST/PUT contains in the request body. 
+     *              If not set, then any request body is valid. The validation is done only if the httpMethod is set.
+     * @param bodyContent the content which should be part of request body.
+     */
+    @MCAttribute
+    public void setBodyContent(String bodyContent) {
+        this.bodyContent = bodyContent;
+    }
+
+
+}

--- a/core/src/main/java/com/predic8/membrane/core/interceptor/shutdown/ShutdownInterceptor.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/shutdown/ShutdownInterceptor.java
@@ -13,10 +13,8 @@
    limitations under the License. */
 package com.predic8.membrane.core.interceptor.shutdown;
 
-import com.predic8.membrane.annot.MCAttribute;
 import com.predic8.membrane.annot.MCElement;
 import com.predic8.membrane.core.exchange.Exchange;
-import com.predic8.membrane.core.http.Request;
 import com.predic8.membrane.core.http.Response;
 import com.predic8.membrane.core.interceptor.AbstractInterceptor;
 import com.predic8.membrane.core.interceptor.Outcome;
@@ -30,77 +28,21 @@ import com.predic8.membrane.core.interceptor.Outcome;
 @MCElement(name="shutdown")
 public class ShutdownInterceptor extends AbstractInterceptor {
     
-    private String httpMethod;
-    private String bodyContent;
-    
     @Override
     public Outcome handleRequest(Exchange exc) throws Exception {
-        if (httpMethod == null // don't check method 
-                || verifyMethodAndContent(exc.getRequest())) {
-            exc.setResponse(Response.ok().contentType("text/plain").body("OK").build());
-            new Thread(new Runnable() {
-                @Override
-                public void run() {
-                    try {
-                        Thread.sleep(100); // Wait a moment to finish this request.
-                    } catch (InterruptedException e) {
-                        // DONOTHING
-                    }
-                    getRouter().stop(); // stop the router
+        exc.setResponse(Response.ok().contentType("text/plain").body("OK").build());
+        new Thread(new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    Thread.sleep(100); // Wait a moment to finish this request.
+                } catch (InterruptedException e) {
+                    // DONOTHING
                 }
-            }).start();
-        } else {
-            exc.setResponse(
-                    Response.badRequest().contentType("text/plain").body("Invalid request to shutdown").build());
-        }
+                getRouter().stop(); // stop the router
+            }
+        }).start();
         return Outcome.RETURN;
     }
-
-    private boolean verifyMethodAndContent(Request request) {
-        boolean ret = false;
-        final String rmethod = request.getMethod();
-        if (httpMethod.equals(rmethod)) {
-            ret = true;
-            if (bodyContent != null && (Request.METHOD_POST.equals(rmethod) || Request.METHOD_PUT.equals(rmethod))) {
-                final String rbody = request.getBodyAsStringDecoded();
-                ret = rbody !=null && rbody.contains(bodyContent);
-            }
-        }
-        return ret;
-    }
-
-    /**
-     * @return the HTTP method
-     */
-    public String getHttpMethod() {
-        return httpMethod;
-    }
-
-    /**
-     * @description required HTTP method to shutdown process. If not set, any method is allowed. 
-     * @param httpMethod HTTP-method ( GET/POST/HEAD/DELETE/PUT/TRACE/CONNECT/OPTIONS )
-     */
-    @MCAttribute
-    public void setHttpMethod(String httpMethod) {
-        this.httpMethod = httpMethod;
-    }
-
-    /**
-     * @return the bodyContent
-     */
-    public String getBodyContent() {
-        return bodyContent;
-    }
-
-    /**
-     * @description string which should POST/PUT contains in the request body. 
-     *              If not set, then any request body is valid. The validation is done only if the httpMethod is set.
-     * @param bodyContent the content which should be part of request body.
-     */
-    @MCAttribute
-    public void setBodyContent(String bodyContent) {
-        this.bodyContent = bodyContent;
-    }
-
 
 }


### PR DESCRIPTION
Hello all, 

I would like to add new feature. ShutdownInterceptor enables shutdown router via HTTP-request.
Shutdown request could (and should) be secured in the same way as others requests.

see cli/examples/shutdown
```xml
<router>
        <serviceProxy name="predic8.com" port="2000" ip="127.0.0.1">
            <!-- Accessible only via localhost interface ( ip="127.0.0.1" ).
                 Be careful, if you set up shutdown interceptor to public IP-address.
            -->
            <!-- Only for specific path.
                 Be careful, putting secret code to URL is not good idea, URLs are usually logged. -->
            <path>/shutdown</path>
            
            <!-- !!! don't forget set up security !!! This example is without security. -->

            <!-- The simplest case : any HTTP method (GET/POST/PUT/HEAD/DELETE/TRACE/CONNECT/OPTIONS) to shutdown.
            <shutdown />
            -->

            <!-- only PUT method, other methods (GET/POST/HEAD/DELETE/TRACE/CONNECT/OPTIONS) are ignored
            <shutdown httpMethod="PUT"/>
            -->

            <!-- only POST method where body contains "'secret code'" ( bodyContent is valid only for POST and PUT) -->
            <shutdown httpMethod="POST" bodyContent="'secret code'"/>

            <!-- only DELETE method, bodyContent is not significant (bodyContent is valid only for POST and PUT )
            <shutdown httpMethod="DELETE" bodyContent="anything, because it's not validated"/>
            -->
        </serviceProxy>
    </router>
```

