### PR TITLE
New feature : access to spring application context from groovy interceptor

### DIFF
--- a/cli/examples/groovy/proxies.xml
+++ b/cli/examples/groovy/proxies.xml
@@ -4,16 +4,16 @@
 	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
 					    http://membrane-soa.org/proxies/1/ http://membrane-soa.org/schemas/proxies-1.xsd">
 
-    <spring:bean name="mySpringBean" class="java.lang.String">
-        <spring:constructor-arg value="Groovy interceptor"/>
-    </spring:bean>
+	<spring:bean name="mySpringBean" class="java.lang.String">
+		<spring:constructor-arg value="Groovy interceptor"/>
+	</spring:bean>
 
 	<router>
 	
 		<serviceProxy port="2000">
 			<request>
 				<groovy>
-				    def value = spring.getBean('mySpringBean')
+					def value = spring.getBean('mySpringBean')
 					exc.request.header.add("X-Groovy", value)
 					println "X-Groovy header added with value :" + value
 					CONTINUE

--- a/cli/examples/groovy/proxies.xml
+++ b/cli/examples/groovy/proxies.xml
@@ -4,13 +4,18 @@
 	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
 					    http://membrane-soa.org/proxies/1/ http://membrane-soa.org/schemas/proxies-1.xsd">
 
+    <spring:bean name="mySpringBean" class="java.lang.String">
+        <spring:constructor-arg value="Groovy interceptor"/>
+    </spring:bean>
+
 	<router>
 	
 		<serviceProxy port="2000">
 			<request>
 				<groovy>
-					exc.request.header.add("X-Groovy", "Groovy interceptor")
-					println "X-Groovy header added." 				
+				    def value = spring.getBean('mySpringBean')
+					exc.request.header.add("X-Groovy", value)
+					println "X-Groovy header added with value :" + value
 					CONTINUE
 				</groovy>
 			</request>

--- a/cli/src/test/java/com/predic8/membrane/examples/tests/GroovyTest.java
+++ b/cli/src/test/java/com/predic8/membrane/examples/tests/GroovyTest.java
@@ -29,9 +29,12 @@ public class GroovyTest extends DistributionExtractingTestcase {
 
 	@Test
 	public void test() throws IOException, InterruptedException {
-		Process2 sl = new Process2.Builder().in(getExampleDir("groovy")).script("service-proxy").waitForMembrane().start();
+		Process2 sl = new Process2.Builder().in(getExampleDir("groovy"))
+		        //.withWatcher(new com.predic8.membrane.examples.util.ConsoleLogger())
+		        .script("service-proxy").waitForMembrane().start();
 		try {
-			SubstringWaitableConsoleEvent groovyCalled = new SubstringWaitableConsoleEvent(sl, "X-Groovy header added.");
+			SubstringWaitableConsoleEvent groovyCalled = 
+			        new SubstringWaitableConsoleEvent(sl, "X-Groovy header added with value :Groovy interceptor");
 			getAndAssert200("http://localhost:2000/");
 			assertTrue(groovyCalled.occurred());
 		} finally {

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -12,17 +12,18 @@
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
- --><project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-    <modelVersion>4.0.0</modelVersion>
-    <artifactId>service-proxy-core</artifactId>
-    <packaging>jar</packaging>
+ -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<artifactId>service-proxy-core</artifactId>
+	<packaging>jar</packaging>
 
-    <parent>
-        <groupId>org.membrane-soa.service-proxy</groupId>
-        <artifactId>service-proxy-parent</artifactId>
-        <relativePath>../pom.xml</relativePath>
-        <version>4.0.18-SNAPSHOT</version>
-    </parent>
+	<parent>
+		<groupId>org.membrane-soa.service-proxy</groupId>
+		<artifactId>service-proxy-parent</artifactId>
+		<relativePath>../pom.xml</relativePath>
+		<version>4.0.18-SNAPSHOT</version>
+	</parent>
 	<dependencies>
 		<dependency>
 			<groupId>org.membrane-soa.service-proxy</groupId>
@@ -80,10 +81,10 @@
 			<groupId>com.springsource</groupId>
 			<artifactId>com.springsource.javax.annotation</artifactId>
 		</dependency>
-        <dependency>
-        	<groupId>commons-fileupload</groupId>
-        	<artifactId>commons-fileupload</artifactId>
-        </dependency>
+		<dependency>
+			<groupId>commons-fileupload</groupId>
+			<artifactId>commons-fileupload</artifactId>
+		</dependency>
 		<dependency>
 			<groupId>com.floreysoft</groupId>
 			<artifactId>jmte</artifactId>
@@ -126,10 +127,10 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
-            <scope>test</scope>
-        </dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-core</artifactId>
+			<scope>test</scope>
+		</dependency>
 		<dependency>
 			<groupId>org.apache.httpcomponents</groupId>
 			<artifactId>httpclient</artifactId>
@@ -203,7 +204,6 @@
 					</excludes>
 				</configuration>
 			</plugin>
-
 		</plugins>
 	</build>
 
@@ -242,14 +242,14 @@
 		</profile>
 	</profiles>
 
-  <reporting>
-    <plugins>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>findbugs-maven-plugin</artifactId>
-        <version>2.4.0</version>
-      </plugin>
-    </plugins>
-  </reporting>
-    
+	<reporting>
+		<plugins>
+			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>findbugs-maven-plugin</artifactId>
+				<version>2.4.0</version>
+			</plugin>
+		</plugins>
+	</reporting>
+
 </project>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -126,6 +126,11 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+		<dependency>
 			<groupId>org.apache.httpcomponents</groupId>
 			<artifactId>httpclient</artifactId>
 			<scope>test</scope>

--- a/core/src/main/java/com/predic8/membrane/core/interceptor/groovy/GroovyInterceptor.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/groovy/GroovyInterceptor.java
@@ -66,6 +66,7 @@ public class GroovyInterceptor extends AbstractInterceptor {
     private Outcome runScript(Exchange exc) throws InterruptedException {
     	HashMap<String, Object> parameters = new HashMap<String, Object>();
     	parameters.put("exc", exc);
+    	parameters.put("spring", router.getBeanFactory());
     	
     	Object res = script.apply(parameters);
     	

--- a/core/src/test/java/com/predic8/membrane/core/interceptor/groovy/GroovyInterceptorTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/interceptor/groovy/GroovyInterceptorTest.java
@@ -13,33 +13,39 @@
    limitations under the License. */
 package com.predic8.membrane.core.interceptor.groovy;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
 
 import org.junit.Test;
+import org.springframework.context.ApplicationContext;
 
 import com.predic8.membrane.core.HttpRouter;
 import com.predic8.membrane.core.exchange.Exchange;
 import com.predic8.membrane.core.http.Request;
 import com.predic8.membrane.core.interceptor.Outcome;
 
-public class GroovyInterceptorTest extends TestCase {
-		
+public class GroovyInterceptorTest {
+    
+    private ApplicationContext applicationContext = mock(ApplicationContext.class);
+    
 	@Test
 	public void testRequest() throws Exception {
 		HttpRouter r = new HttpRouter();
+		r.setApplicationContext(applicationContext);
+		when(applicationContext.getBean("abc")).thenReturn("OK");
 		
 		Exchange exc = new Exchange(null);
 		exc.setRequest(new Request());
 		
 		GroovyInterceptor i = new GroovyInterceptor();
 		i.setSrc("exc.setProperty('foo', 'bar')\n"+
+		         "def b = spring.getBean('abc')\n"+
 				 "CONTINUE");
 		i.init(r);
 		
 		assertEquals(Outcome.CONTINUE, i.handleRequest(exc));
-		
 		assertEquals("bar", exc.getProperty("foo"));
-		
+		verify(applicationContext, times(1)).getBean("abc");
 	}
 	
 }

--- a/pom.xml
+++ b/pom.xml
@@ -62,6 +62,7 @@
 		<javac.source>1.6</javac.source>
 		<javac.target>1.6</javac.target>
         <jackson.version>1.9.11</jackson.version> <!-- This version is used by google-http-client-jackson -->
+        <powermock.version>1.6.0</powermock.version>
 	</properties>
 
 	<dependencyManagement>
@@ -233,12 +234,30 @@
 				<artifactId>jsr305</artifactId>
 				<version>2.0.1</version>
 			</dependency>
-
 			<dependency>
 				<groupId>junit</groupId>
 				<artifactId>junit</artifactId>
 				<version>4.11</version>
-			</dependency>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.mockito</groupId>
+                <artifactId>mockito-core</artifactId>
+                <version>1.10.8</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.powermock</groupId>
+                <artifactId>powermock-api-mockito</artifactId>
+                <version>${powemock.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.powermock</groupId>
+                <artifactId>powermock-module-junit4</artifactId>
+                <version>${powemock.version}</version>
+                <scope>test</scope>
+            </dependency>
 			<dependency>
 				<groupId>commons-httpclient</groupId>
 				<artifactId>commons-httpclient</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,8 @@
 	Unless required by applicable law or agreed to in writing, software distributed 
 	under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES 
 	OR CONDITIONS OF ANY KIND, either express or implied. See the License for 
-	the specific language governing permissions and limitations under the License. --><project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	the specific language governing permissions and limitations under the License. -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.membrane-soa.service-proxy</groupId>
@@ -33,10 +34,10 @@
 		<tag>HEAD</tag>
 	</scm>
 
-    <issueManagement>
-        <system>Github Issue Tracker</system>
-        <url>https://github.com/membrane/service-proxy/issues</url>
-    </issueManagement>
+	<issueManagement>
+		<system>Github Issue Tracker</system>
+		<url>https://github.com/membrane/service-proxy/issues</url>
+	</issueManagement>
 
 	<mailingLists>
 		<mailingList>
@@ -61,8 +62,8 @@
 		<project.reporting.outputEncoding>ISO-8859-1</project.reporting.outputEncoding>
 		<javac.source>1.6</javac.source>
 		<javac.target>1.6</javac.target>
-        <jackson.version>1.9.11</jackson.version> <!-- This version is used by google-http-client-jackson -->
-        <powermock.version>1.6.0</powermock.version>
+		<jackson.version>1.9.11</jackson.version> <!-- This version is used by google-http-client-jackson -->
+		<powermock.version>1.6.0</powermock.version>
 	</properties>
 
 	<dependencyManagement>
@@ -238,26 +239,26 @@
 				<groupId>junit</groupId>
 				<artifactId>junit</artifactId>
 				<version>4.11</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.mockito</groupId>
-                <artifactId>mockito-core</artifactId>
-                <version>1.10.8</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.powermock</groupId>
-                <artifactId>powermock-api-mockito</artifactId>
-                <version>${powemock.version}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.powermock</groupId>
-                <artifactId>powermock-module-junit4</artifactId>
-                <version>${powemock.version}</version>
-                <scope>test</scope>
-            </dependency>
+				<scope>test</scope>
+			</dependency>
+			<dependency>
+				<groupId>org.mockito</groupId>
+				<artifactId>mockito-core</artifactId>
+				<version>1.10.8</version>
+				<scope>test</scope>
+			</dependency>
+			<dependency>
+				<groupId>org.powermock</groupId>
+				<artifactId>powermock-api-mockito</artifactId>
+				<version>${powermock.version}</version>
+				<scope>test</scope>
+			</dependency>
+			<dependency>
+				<groupId>org.powermock</groupId>
+				<artifactId>powermock-module-junit4</artifactId>
+				<version>${powermock.version}</version>
+				<scope>test</scope>
+			</dependency>
 			<dependency>
 				<groupId>commons-httpclient</groupId>
 				<artifactId>commons-httpclient</artifactId>
@@ -443,42 +444,42 @@
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-jar-plugin</artifactId>
 					<version>2.4</version>
-                    <configuration>
-                        <archive>
-                            <manifest>
-                                <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
-                                <addDefaultSpecificationEntries>true</addDefaultSpecificationEntries>
-                            </manifest>
-                        </archive>
+					<configuration>
+						<archive>
+							<manifest>
+								<addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+								<addDefaultSpecificationEntries>true</addDefaultSpecificationEntries>
+							</manifest>
+						</archive>
 					</configuration>
 				</plugin>
 				
-                <plugin>
-                    <artifactId>maven-ejb-plugin</artifactId>
-                    <version>2.3</version>
-                    <configuration>
-                        <archive>
-                            <manifest>
-                                <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
-                                <addDefaultSpecificationEntries>true</addDefaultSpecificationEntries>
-                            </manifest>
-                        </archive>
-                    </configuration>
-                </plugin>
+				<plugin>
+					<artifactId>maven-ejb-plugin</artifactId>
+					<version>2.3</version>
+					<configuration>
+						<archive>
+							<manifest>
+								<addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+								<addDefaultSpecificationEntries>true</addDefaultSpecificationEntries>
+							</manifest>
+						</archive>
+					</configuration>
+				</plugin>
 
-                <plugin>
-                    <artifactId>maven-war-plugin</artifactId>
-                    <version>2.2</version>
-                    <configuration>
-                        <archive>
-                            <manifest>
-                                <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
-                                <addDefaultSpecificationEntries>true</addDefaultSpecificationEntries>
-                            </manifest>
-                        </archive>
-                    </configuration>
-                </plugin>
-				
+				<plugin>
+					<artifactId>maven-war-plugin</artifactId>
+					<version>2.2</version>
+					<configuration>
+						<archive>
+							<manifest>
+								<addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+								<addDefaultSpecificationEntries>true</addDefaultSpecificationEntries>
+							</manifest>
+						</archive>
+					</configuration>
+				</plugin>
+
 				<plugin>
 					<groupId>org.codehaus.mojo</groupId>
 					<artifactId>exec-maven-plugin</artifactId>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -29,6 +29,7 @@
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
+			<scope>compile</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.httpcomponents</groupId>


### PR DESCRIPTION
example :
    <spring:bean name="mySpringBean" class="java.lang.String">
        <spring:constructor-arg value="Groovy interceptor"/>
    </spring:bean>

    <router>
        <serviceProxy port="2000">
            <request>
                <groovy>
                    def value = spring.getBean("mySpringBean")
                    exc.request.header.add("X-Groovy", value)
                    println "X-Groovy header added with value :" + value
                    CONTINUE
                </groovy>
            </request>
        </serviceProxy>
    </router>