### PR TITLE
Avoid considering value that start with 0 as Number (ex. 003)

### DIFF
--- a/core/src/main/resources/com/predic8/membrane/core/interceptor/rest/xml2json.xsl
+++ b/core/src/main/resources/com/predic8/membrane/core/interceptor/rest/xml2json.xsl
@@ -124,8 +124,8 @@
     </xsl:choose>
   </xsl:template>
 
-  <!-- number (no support for javascript mantise) -->
-  <xsl:template match="text()[not(string(number())='NaN')]">
+  <!-- number (no support for javascript mantise)-->
+  <xsl:template match="text()[not(string(number())='NaN' or (starts-with(.,'0' ) and . != '0'))]">
     <xsl:value-of select="."/>
   </xsl:template>
 


### PR DESCRIPTION
bad generation of json when the xml contains values as (007, 04 ...), are considered as Number and miss the double quote.