### PR TITLE
added cross-origin header to make the JSON response available to cross-domain API calls

### DIFF
--- a/core/src/main/java/com/predic8/membrane/core/interceptor/schemavalidation/JSONValidator.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/schemavalidation/JSONValidator.java
@@ -106,20 +106,22 @@ public class JSONValidator implements IValidator {
         for (String message : errors)
         	jg.writeString(message);
         jg.close();
-        	
+        				
 		if (failureHandler != null) {
 			failureHandler.handleFailure(new String(baos.toByteArray(), UTF8), exc);
 			exc.setResponse(Response.badRequest().
+					header("Access-Control-Allow-Origin",  "*"). // enable cross-origin ajax response
 					contentType("application/json;charset=utf-8").
 					body("{\"error\":\"error\"}".getBytes(UTF8)).
 					build());
 		} else {
 	        exc.setResponse(Response.badRequest().
+					header("Access-Control-Allow-Origin",  "*"). // enable cross-origin ajax response
 	        		contentType("application/json;charset=utf-8").
 	        		body(baos.toByteArray()).
 	        		build());
 		}
-		
+
         invalid.incrementAndGet();
 		return Outcome.ABORT;
 	}


### PR DESCRIPTION
It's vital when using membrane to front JSON API used in cross domain situations.