### PR TITLE
Made DummyWebServiceInterceptor thread safe. 

### DIFF
--- a/core/src/main/java/com/predic8/membrane/core/interceptor/Interceptor.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/Interceptor.java
@@ -19,6 +19,12 @@ import java.util.EnumSet;
 import com.predic8.membrane.core.Router;
 import com.predic8.membrane.core.exchange.Exchange;
 
+/**
+ * TODO describe in short what an interceptor is.
+ *
+ * Interceptor implementations need to be thread safe.
+ *
+ */
 public interface Interceptor {
 
 	public enum Flow {

--- a/core/src/test/java/com/predic8/membrane/core/interceptor/balancer/LoadBalancingWithClusterManagerTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/interceptor/balancer/LoadBalancingWithClusterManagerTest.java
@@ -58,37 +58,37 @@ public class LoadBalancingWithClusterManagerTest {
 		sendNotification("up", 3000);
 
 		assertEquals(200, post("/getBankwithSession555555.xml"));// goes to service one
-		assertEquals(1, service1.counter);
-		assertEquals(0, service2.counter);
+		assertEquals(1, service1.getCount());
+		assertEquals(0, service2.getCount());
 
 		assertEquals(200, post("/getBankwithSession555555.xml"));// goes to service 1 again
-		assertEquals(2, service1.counter);
-		assertEquals(0, service2.counter);
+		assertEquals(2, service1.getCount());
+		assertEquals(0, service2.getCount());
 
 		assertEquals(200, post("/getBankwithSession444444.xml")); // goes to service 2
-		assertEquals(2, service1.counter);
-		assertEquals(1, service2.counter);
+		assertEquals(2, service1.getCount());
+		assertEquals(1, service2.getCount());
 
 		sendNotification("down", 2000);
 
 		assertEquals(200, post("/getBankwithSession555555.xml")); // goes to service 2 because service 1 is down
-		assertEquals(2, service1.counter);
-		assertEquals(2, service2.counter);
+		assertEquals(2, service1.getCount());
+		assertEquals(2, service2.getCount());
 
 		sendNotification("up", 4000);
 
-		assertEquals(0, service3.counter);
+		assertEquals(0, service3.getCount());
 		assertEquals(200, post("/getBankwithSession666666.xml")); // goes to service 3
-		assertEquals(2, service1.counter);
-		assertEquals(2, service2.counter);
-		assertEquals(1, service3.counter);
+		assertEquals(2, service1.getCount());
+		assertEquals(2, service2.getCount());
+		assertEquals(1, service3.getCount());
 
 		assertEquals(200, post("/getBankwithSession555555.xml")); // goes to service 2
 		assertEquals(200, post("/getBankwithSession444444.xml")); // goes to service 2
 		assertEquals(200, post("/getBankwithSession666666.xml")); // goes to service 3
-		assertEquals(2, service1.counter);
-		assertEquals(4, service2.counter);
-		assertEquals(2, service3.counter);
+		assertEquals(2, service1.getCount());
+		assertEquals(4, service2.getCount());
+		assertEquals(2, service3.getCount());
 
 
 	}

--- a/core/src/test/java/com/predic8/membrane/core/services/DummyWebServiceInterceptor.java
+++ b/core/src/test/java/com/predic8/membrane/core/services/DummyWebServiceInterceptor.java
@@ -21,18 +21,24 @@ import com.predic8.membrane.core.http.Response;
 import com.predic8.membrane.core.interceptor.AbstractInterceptor;
 import com.predic8.membrane.core.interceptor.Outcome;
 
+import java.util.concurrent.atomic.AtomicLong;
+
 public class DummyWebServiceInterceptor extends AbstractInterceptor {
 
 	private static Log log = LogFactory.getLog(DummyWebServiceInterceptor.class.getName());
 
-	public volatile long counter;
+    private AtomicLong counter = new AtomicLong();
 
 	@Override
 	public Outcome handleRequest(Exchange exc) throws Exception {
 		exc.setResponse(Response.ok().contentType("text/html").body("<aaa></aaa>".getBytes()).build());
-		counter ++;
-		log.debug("handle request "+counter);
+        long count = counter.incrementAndGet();
+        log.debug("handle request "+count);
 		return Outcome.RETURN;
 	}
+
+   public long getCount() {
+      return counter.get();
+   }
 
 }

--- a/core/src/test/java/com/predic8/membrane/interceptor/LoadBalancingInterceptorTest.java
+++ b/core/src/test/java/com/predic8/membrane/interceptor/LoadBalancingInterceptorTest.java
@@ -160,20 +160,20 @@ public class LoadBalancingInterceptorTest {
 		//System.out.println(new String(vari.getResponseBody()));
 
 		assertEquals(200, status);
-		assertEquals(1, mockInterceptor1.counter);
-		assertEquals(0, mockInterceptor2.counter);
+		assertEquals(1, mockInterceptor1.getCount());
+		assertEquals(0, mockInterceptor2.getCount());
 
 		assertEquals(200, client.executeMethod(getPostMethod()));
-		assertEquals(1, mockInterceptor1.counter);
-		assertEquals(1, mockInterceptor2.counter);
+		assertEquals(1, mockInterceptor1.getCount());
+		assertEquals(1, mockInterceptor2.getCount());
 
 		assertEquals(200, client.executeMethod(getPostMethod()));
-		assertEquals(2, mockInterceptor1.counter);
-		assertEquals(1, mockInterceptor2.counter);
+		assertEquals(2, mockInterceptor1.getCount());
+		assertEquals(1, mockInterceptor2.getCount());
 
 		assertEquals(200, client.executeMethod(getPostMethod()));
-		assertEquals(2, mockInterceptor1.counter);
-		assertEquals(2, mockInterceptor2.counter);
+		assertEquals(2, mockInterceptor1.getCount());
+		assertEquals(2, mockInterceptor2.getCount());
 	}
 
 	@Test
@@ -187,20 +187,20 @@ public class LoadBalancingInterceptorTest {
 		int status = client.executeMethod(vari);
 
 		assertEquals(200, status);
-		assertEquals(1, mockInterceptor1.counter);
-		assertEquals(0, mockInterceptor2.counter);
+		assertEquals(1, mockInterceptor1.getCount());
+		assertEquals(0, mockInterceptor2.getCount());
 
 		assertEquals(200, client.executeMethod(getPostMethod()));
-		assertEquals(1, mockInterceptor1.counter);
-		assertEquals(1, mockInterceptor2.counter);
+		assertEquals(1, mockInterceptor1.getCount());
+		assertEquals(1, mockInterceptor2.getCount());
 
 		assertEquals(200, client.executeMethod(getPostMethod()));
-		assertEquals(2, mockInterceptor1.counter);
-		assertEquals(1, mockInterceptor2.counter);
+		assertEquals(2, mockInterceptor1.getCount());
+		assertEquals(1, mockInterceptor2.getCount());
 
 		assertEquals(200, client.executeMethod(getPostMethod()));
-		assertEquals(2, mockInterceptor1.counter);
-		assertEquals(2, mockInterceptor2.counter);
+		assertEquals(2, mockInterceptor1.getCount());
+		assertEquals(2, mockInterceptor2.getCount());
 	}
 
 	private PostMethod getPostMethod() {
@@ -223,22 +223,22 @@ public class LoadBalancingInterceptorTest {
 				HttpVersion.HTTP_1_1);
 
 		assertEquals(200, client.executeMethod(getPostMethod()));
-		assertEquals(1, mockInterceptor1.counter);
-		assertEquals(0, mockInterceptor2.counter);
+		assertEquals(1, mockInterceptor1.getCount());
+		assertEquals(0, mockInterceptor2.getCount());
 
 		assertEquals(200, client.executeMethod(getPostMethod()));
-		assertEquals(1, mockInterceptor1.counter);
-		assertEquals(1, mockInterceptor2.counter);
+		assertEquals(1, mockInterceptor1.getCount());
+		assertEquals(1, mockInterceptor2.getCount());
 
 		service1.shutdown();
 		Thread.sleep(1000);
 
 		assertEquals(200, client.executeMethod(getPostMethod()));
-		assertEquals(1, mockInterceptor1.counter);
-		assertEquals(2, mockInterceptor2.counter);
+		assertEquals(1, mockInterceptor1.getCount());
+		assertEquals(2, mockInterceptor2.getCount());
 
 		assertEquals(200, client.executeMethod(getPostMethod()));
-		assertEquals(3, mockInterceptor2.counter);
+		assertEquals(3, mockInterceptor2.getCount());
 
 	}
 
@@ -251,12 +251,12 @@ public class LoadBalancingInterceptorTest {
 				HttpVersion.HTTP_1_1);
 
 		assertEquals(200, client.executeMethod(getPostMethod()));
-		assertEquals(1, mockInterceptor1.counter);
-		assertEquals(0, mockInterceptor2.counter);
+		assertEquals(1, mockInterceptor1.getCount());
+		assertEquals(0, mockInterceptor2.getCount());
 
 		assertEquals(200, client.executeMethod(getPostMethod()));
-		assertEquals(1, mockInterceptor1.counter);
-		assertEquals(1, mockInterceptor2.counter);
+		assertEquals(1, mockInterceptor1.getCount());
+		assertEquals(1, mockInterceptor2.getCount());
 
 		((ServiceProxy)service1.getRuleManager().getRules().get(0)).getInterceptors().add(0, new AbstractInterceptor(){
 			@Override
@@ -267,11 +267,11 @@ public class LoadBalancingInterceptorTest {
 		});
 
 		assertEquals(200, client.executeMethod(getPostMethod()));
-		assertEquals(1, mockInterceptor1.counter);
-		assertEquals(2, mockInterceptor2.counter);
+		assertEquals(1, mockInterceptor1.getCount());
+		assertEquals(2, mockInterceptor2.getCount());
 
 		assertEquals(200, client.executeMethod(getPostMethod()));
-		assertEquals(3, mockInterceptor2.counter);
+		assertEquals(3, mockInterceptor2.getCount());
 
 	}
 

--- a/core/src/test/java/com/predic8/membrane/interceptor/MultipleLoadBalancersTest.java
+++ b/core/src/test/java/com/predic8/membrane/interceptor/MultipleLoadBalancersTest.java
@@ -111,10 +111,10 @@ public class MultipleLoadBalancersTest {
 	}
 
 	private void assertMockCounters(int n1, int n2, int n11, int n12) {
-		assertEquals(n1, service1.mockInterceptor1.counter);
-		assertEquals(n2, service2.mockInterceptor1.counter);
-		assertEquals(n11, service11.mockInterceptor1.counter);
-		assertEquals(n12, service12.mockInterceptor1.counter);
+		assertEquals(n1, service1.mockInterceptor1.getCount());
+		assertEquals(n2, service2.mockInterceptor1.getCount());
+		assertEquals(n11, service11.mockInterceptor1.getCount());
+		assertEquals(n12, service12.mockInterceptor1.getCount());
 	}
 
 	@Test


### PR DESCRIPTION
Note: this class is only used by tests, therefore that's not a critical issue.

Currently there are no tests using multi-threading. In my own tests (contributions will follow) firing 100 requests, the volatile counter consistently got to 96-97 because the ++ operation is not atomic.