### PR TITLE
LoadBalancingInterceptor: added missing call to DispatchingStrategy.done()

### DIFF
--- a/core/src/main/java/com/predic8/membrane/core/interceptor/balancer/LoadBalancingInterceptor.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/balancer/LoadBalancingInterceptor.java
@@ -90,6 +90,7 @@ public class LoadBalancingInterceptor extends AbstractInterceptor {
 		}
 
 		updateDispatchedNode(exc);
+		strategy.done(exc);
 
 		return Outcome.CONTINUE;
 	}


### PR DESCRIPTION
as suggested by Thomas Bayer on the mailing list https://mail.google.com/mail/u/0/#inbox/146db8f4a04962ee