### PR TITLE
exception.printStackTrace() was replaced with LOG.error(...)

### DIFF
--- a/core/src/main/java/com/predic8/membrane/core/RouterCLI.java
+++ b/core/src/main/java/com/predic8/membrane/core/RouterCLI.java
@@ -14,6 +14,8 @@
 
 package com.predic8.membrane.core;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.xml.XmlBeanDefinitionStoreException;
 
 import com.predic8.membrane.core.config.spring.CheckableBeanFactory.InvalidConfigurationException;
@@ -23,6 +25,8 @@ import com.predic8.membrane.core.resolver.ResourceRetrievalException;
 
 
 public class RouterCLI {
+
+    private static final Logger LOG = LoggerFactory.getLogger(RouterCLI.class);
 
 	public static void main(String[] args) {
 
@@ -43,6 +47,7 @@ public class RouterCLI {
 			System.err.println("Fatal error: " + e.getMessage());
 			System.exit(1);
 		} catch (Exception ex) {
+		    LOG.error(ex.getMessage(), ex);
 			ex.printStackTrace();
 			System.exit(1);
 		}

--- a/core/src/main/java/com/predic8/membrane/core/transport/http/StreamPump.java
+++ b/core/src/main/java/com/predic8/membrane/core/transport/http/StreamPump.java
@@ -123,7 +123,7 @@ public class StreamPump implements Runnable {
 			in.close();
 			out.close();
 		} catch (IOException e) {
-			e.printStackTrace();
+			log.error(e.getMessage(), e);
 		}
 	}
 

--- a/core/src/test/java/com/predic8/membrane/core/interceptor/xmlprotection/XMLProtectorTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/interceptor/xmlprotection/XMLProtectorTest.java
@@ -19,6 +19,9 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import junit.framework.TestCase;
 
 import com.predic8.membrane.core.Constants;
@@ -27,6 +30,7 @@ import com.predic8.membrane.core.util.ByteUtil;
 
 public class XMLProtectorTest extends TestCase {
 
+    private static final Logger LOG = LoggerFactory.getLogger(XMLProtectorTest.class);
 	private XMLProtector xmlProtector;
 	private byte[] input, output;
 
@@ -58,7 +62,7 @@ public class XMLProtectorTest extends TestCase {
 		try {
 			bos.write(input);
 		} catch (IOException e) {
-			e.printStackTrace();
+			LOG.error(e.getMessage(), e);
 		}
 		StringBuffer sb = new StringBuffer();
 		sb.append(bos.toString());

--- a/core/src/test/java/com/predic8/membrane/core/util/DNSCacheTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/util/DNSCacheTest.java
@@ -22,9 +22,11 @@ import java.net.InetAddress;
 import java.net.UnknownHostException;
 
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class DNSCacheTest {
-
+    private static final Logger LOG = LoggerFactory.getLogger(DNSCacheTest.class);
 	private DNSCache cache = new DNSCache();
 
 	private static InetAddress address;
@@ -33,7 +35,7 @@ public class DNSCacheTest {
 		try {
 			address = InetAddress.getByName("localhost");
 		} catch (UnknownHostException e) {
-			e.printStackTrace();
+			LOG.error(e.getMessage(), e);
 		}
 	}
 

--- a/war/src/main/java/com/predic8/membrane/servlet/embedded/HttpServletHandler.java
+++ b/war/src/main/java/com/predic8/membrane/servlet/embedded/HttpServletHandler.java
@@ -88,7 +88,7 @@ class HttpServletHandler extends AbstractHttpHandler {
 			log.debug("Client connection terminated before line was read. Line so far: ("
 					+ e.getLineSoFar() + ")");
 		} catch (Exception e) {
-			e.printStackTrace();
+			log.error(e.getMessage(), e);
 		} finally {
 			exchange.detach();
 		}

--- a/war/src/test/java/com/predic8/membrane/servlet/test/ResolverTestTriggerTest.java
+++ b/war/src/test/java/com/predic8/membrane/servlet/test/ResolverTestTriggerTest.java
@@ -27,6 +27,8 @@ import org.junit.runner.Request;
 import org.junit.runner.Result;
 import org.junit.runner.notification.Failure;
 import org.junit.runners.Parameterized;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.predic8.membrane.core.exchange.Exchange;
 import com.predic8.membrane.core.http.Header;
@@ -38,6 +40,7 @@ import com.predic8.membrane.core.resolver.SchemaResolver;
 
 public class ResolverTestTriggerTest extends AbstractInterceptor {
 
+    private static final Logger LOG = LoggerFactory.getLogger(ResolverTestTriggerTest.class);
 	private static final String MAGIC = "MAGIC463634623\n";
 
 	@Override
@@ -71,7 +74,7 @@ public class ResolverTestTriggerTest extends AbstractInterceptor {
 			exc.setResponse(Response.ok().header(Header.CONTENT_TYPE, MimeType.TEXT_PLAIN_UTF8).body(sb.toString()).build());
 
 		} catch (Throwable t) {
-			t.printStackTrace();
+			LOG.error(t.getMessage(), t);
 		}
 		return Outcome.RETURN;
 	}


### PR DESCRIPTION
Simple patch which removes a few warning about usage exception.printStackTrace().