### PR TITLE
wrap any validation error with AbortException.

### DIFF
--- a/core/src/main/java/com/predic8/membrane/core/interceptor/schemavalidation/ValidatorInterceptor.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/schemavalidation/ValidatorInterceptor.java
@@ -104,8 +104,12 @@ public class ValidatorInterceptor extends AbstractInterceptor implements Applica
 	public Outcome handleRequest(Exchange exc) throws Exception {
 		if (exc.getRequest().isBodyEmpty()) 
 			return Outcome.CONTINUE;
-			
-		return validator.validateMessage(exc, exc.getRequest(), "request");
+		
+		try { // added by Victor to wrap any validation error with AbortException. This shall prevent membrane from quitting unexpectedly when validation throws IOException, e.g.Jackson's JSON lib
+			return validator.validateMessage(exc, exc.getRequest(), "request");
+		} catch (Exception e) {
+			throw new com.predic8.membrane.core.transport.http.AbortException(e.getMessage());
+		}
 	}
 	
 	@Override


### PR DESCRIPTION
By wrapping the validation action with try-catch and AbortException, it prevents membrane from quitting unexpectedly when the underlying validation code fails and throws validation exception incorrectly inherited from IOException, such as the default Jackson JSON validator framework.

Because Jackson's JSONParseException inherits IOException, membrane will simply disconnect when the parser failed, e.g. upon any invalid JSON format, and resulted in membrane uncaught exception and unexpected response result.