### PR TITLE
Bypass SSL cert validation when ignoreTimestampFailure flag is set to true.

### DIFF
--- a/core/src/main/java/com/predic8/membrane/core/transport/ssl/SSLContext.java
+++ b/core/src/main/java/com/predic8/membrane/core/transport/ssl/SSLContext.java
@@ -118,7 +118,22 @@ public class SSLContext implements SSLProvider {
 			
 			TrustManager[] tms = tmf != null ? tmf.getTrustManagers() : null /* trust anyone: new TrustManager[] { new NullTrustManager() } */;
 			if (sslParser.isIgnoreTimestampCheckFailure())
-				tms = new TrustManager[] { new TrustManagerWrapper(tms, true) };
+				tms = new TrustManager[] { new javax.net.ssl.X509TrustManager() { // treat isIgnoreTimestampCheckFailure as trust-anyone
+                                                @Override
+                                                public void checkClientTrusted(java.security.cert.X509Certificate[] xcs, String string) 
+                                                    throws java.security.cert.CertificateException {
+                                                }
+                                                @Override
+                                                public void checkServerTrusted(java.security.cert.X509Certificate[] xcs, String string) 
+                                                    throws java.security.cert.CertificateException {
+                                                }
+                                                @Override
+                                                public java.security.cert.X509Certificate[] getAcceptedIssuers() {
+                                                    return null; // SECURITY ALERT
+                                                }
+                                            }
+                                         };
+            
 			
 			if (sslParser.getProtocol() != null)
 				sslc = javax.net.ssl.SSLContext.getInstance(sslParser.getProtocol());


### PR DESCRIPTION
Previously setting ignoreTimestampFailure to true only ignores timestamp failure of the cert, which is of very limited use. Because if user doesn't care the expiration of cert, then most likely a self-signed cert will be used instead. In such case, bypassing the whole cert validation is often required instead of only ignoring the timestamp.
