### PR TITLE
Maven Plugin for Service Proxy

### DIFF
--- a/maven-plugin/README.md
+++ b/maven-plugin/README.md
@@ -1,0 +1,32 @@
+Membrane Service Proxy Maven Plugin
+===================================
+
+This Maven plugin allows running Service Proxy from Maven.
+
+Configuration
+-------------
+
+Add the following to the `<build>` section of your *pom.xml*:
+
+```xml
+<plugin>
+  <groupId>org.membrane-soa</groupId>
+  <artifactId>service-proxy-maven-plugin</artifactId>
+  <version>4.2.1-SNAPSHOT</version>
+  <configuration>
+    <proxiesXml>src/test/resources/proxies.xml</proxiesXml>
+  </configuration>
+</plugin>
+```
+
+Usage
+-----
+
+Run Service-Proxy with `mvn service-proxy:run`.
+
+Notes
+-----
+
+The plugin currently does not support forking.
+By default, it's bound to the *test-compile* phase. It might or might not fit your needs.
+You can change it by defining the phase explicitly in your pom.

--- a/maven-plugin/pom.xml
+++ b/maven-plugin/pom.xml
@@ -1,0 +1,39 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.membrane-soa</groupId>
+  <artifactId>service-proxy-maven-plugin</artifactId>
+  <packaging>maven-plugin</packaging>
+  <version>4.2.1-SNAPSHOT</version>
+  <name>service-proxy-maven-plugin Maven Mojo</name>
+  <url>http://maven.apache.org</url>
+	<parent>
+		<groupId>org.membrane-soa</groupId>
+		<artifactId>service-proxy-parent</artifactId>
+		<relativePath>../pom.xml</relativePath>
+		<version>4.2.1-SNAPSHOT</version>
+	</parent>
+
+  <dependencies>
+
+    <dependency>
+      <groupId>org.membrane-soa</groupId>
+	    <artifactId>service-proxy-core</artifactId>
+    </dependency>
+		<dependency>
+			<groupId>org.springframework</groupId>
+			<artifactId>spring-context</artifactId>
+		</dependency>
+    <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-plugin-api</artifactId>
+      <version>2.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven.plugin-tools</groupId>
+      <artifactId>maven-plugin-annotations</artifactId>
+      <version>3.4</version>
+      <scope>provided</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/maven-plugin/src/main/java/com/predic8/membrane/maven/ServiceProxyMojo.java
+++ b/maven-plugin/src/main/java/com/predic8/membrane/maven/ServiceProxyMojo.java
@@ -1,0 +1,85 @@
+/* Copyright 2009, 2012, 2015 predic8 GmbH, www.predic8.com
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
+package com.predic8.membrane.maven;
+
+import com.predic8.membrane.core.Router;
+
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.logging.Log;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugins.annotations.Execute;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.plugins.annotations.ResolutionScope;
+
+import java.io.File;
+
+/**
+ * Runs Membrane-SOA service proxy within Maven.
+ */
+@Mojo(name = "run", requiresProject = true, defaultPhase = LifecyclePhase.VALIDATE, requiresDependencyResolution = ResolutionScope.TEST)
+@Execute(phase = LifecyclePhase.TEST_COMPILE)
+public class ServiceProxyMojo
+    extends AbstractMojo {
+    /**
+     * Location of the proxies.xml file.
+     * @required
+     */
+    @Parameter(property="service-proxy.proxiesXml", defaultValue="src/test/resources/proxies.xml", required=true, readonly=true)
+    private String proxiesXml;
+
+    /**
+     * Launches Membrane-SOA's service-proxy in a new thread.
+     * @throws MojoExecutionException if the proxy fails.
+     */
+    @Override
+    public void execute()
+        throws MojoExecutionException {
+
+        validateInput(getLog());
+
+        Router.init(proxiesXml, getClass().getClassLoader());
+
+        while (true) {
+            try {
+                Thread.sleep(5000);
+            } catch (InterruptedException interrupted) {
+                // do nothing.
+            }
+        }
+    }
+
+    /**
+     * Validates the Mojo input.
+     * @param logger the {@link Logger} instance.
+     * @throws MojoExecutionException if the configuration is invalid.
+     */
+    protected void validateInput(Log logger)
+        throws MojoExecutionException {
+        String message = null;
+
+        if (! new File(proxiesXml).exists()) {
+            message = proxiesXml + " does not exist";
+        } else if (! new File(proxiesXml).canRead()) {
+            message = proxiesXml + " is not readable";
+        }
+
+        if (message != null) {
+            logger.error(message);
+            throw new MojoExecutionException(message);
+        }
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -71,6 +71,7 @@
 		<module>war</module>
 		<module>sar</module>
 		<module>test</module>
+		<module>maven-plugin</module>
 	</modules>
 
 	<properties>


### PR DESCRIPTION
We wanted to run service-proxy in our Maven project, and decided to write this initial plugin.
It works fine for us so far. We run it in isolation from the rest of the plugins.
Please review it and suggest anything you might find inconvenient.

Thank you!
