### PR TITLE
issue #59: Context path missing from WSDL endpoint

### DIFF
--- a/core/src/main/java/com/predic8/membrane/core/interceptor/WADLInterceptor.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/WADLInterceptor.java
@@ -50,7 +50,7 @@ public class WADLInterceptor extends RelocatingInterceptor {
 
 		Relocator relocator = new Relocator(new OutputStreamWriter(stream,
 				exc.getResponse().getCharset()), getLocationProtocol(), getLocationHost(exc),
-				getLocationPort(exc), pathRewriter);
+				getLocationPort(exc), exc.getHandler().getContextPath(exc), pathRewriter);
 
 		relocator.getRelocatingAttributes().put(
 				new QName(WADL_NS, "resources"), "base");

--- a/core/src/main/java/com/predic8/membrane/core/interceptor/WSDLInterceptor.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/WSDLInterceptor.java
@@ -79,7 +79,7 @@ public class WSDLInterceptor extends RelocatingInterceptor {
 
 		Relocator relocator = new Relocator(new OutputStreamWriter(stream,
 				exc.getResponse().getCharset()), getLocationProtocol(), getLocationHost(exc),
-				getLocationPort(exc), pathRewriter);
+				getLocationPort(exc), exc.getHandler().getContextPath(exc), pathRewriter);
 
 		if (rewriteEndpoint) {
 			relocator.getRelocatingAttributes().put(

--- a/core/src/main/java/com/predic8/membrane/core/interceptor/rewrite/ReverseProxyingInterceptor.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/rewrite/ReverseProxyingInterceptor.java
@@ -68,7 +68,7 @@ public class ReverseProxyingInterceptor extends AbstractInterceptor {
 		// rewrite to our schema, host and port
 		exc.getRequest().getHeader().setValue(Header.DESTINATION,
 				Relocator.getNewLocation(destination, target.getProtocol(),
-						target.getHost(), target.getPort() == -1 ? target.getDefaultPort() : target.getPort()));
+						target.getHost(), target.getPort() == -1 ? target.getDefaultPort() : target.getPort(), exc.getHandler().getContextPath(exc)));
 		return Outcome.CONTINUE;
 	}
 
@@ -98,7 +98,7 @@ public class ReverseProxyingInterceptor extends AbstractInterceptor {
 		// rewrite to our schema, host and port
 		exc.getResponse().getHeader().setValue(Header.LOCATION,
 				Relocator.getNewLocation(location, getProtocol(exc),
-						exc.getOriginalHostHeaderHost(), getPort(exc)));
+						exc.getOriginalHostHeaderHost(), getPort(exc), exc.getHandler().getContextPath(exc)));
 		return Outcome.CONTINUE;
 	}
 

--- a/core/src/main/java/com/predic8/membrane/core/interceptor/soap/WebServiceExplorerInterceptor.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/soap/WebServiceExplorerInterceptor.java
@@ -150,7 +150,7 @@ public class WebServiceExplorerInterceptor extends RESTInterceptor {
 	private String getClientURL(Exchange exc) {
 		// TODO: move this to some central location
 		try {
-			String uri = exc.getRequestURI();
+			String uri = exc.getHandler().getContextPath(exc) + exc.getRequestURI();
 			String host = exc.getRequest().getHeader().getHost();
 			if (host != null) {
 				if (host.contains(":"))

--- a/core/src/main/java/com/predic8/membrane/core/ws/relocator/Relocator.java
+++ b/core/src/main/java/com/predic8/membrane/core/ws/relocator/Relocator.java
@@ -47,6 +47,7 @@ public class Relocator {
 
 	private final String host;
 	private final int port;
+	private final String contextPath;
 	private final String protocol;
 	private final XMLEventWriter writer;
 	private final PathRewriter pathRewriter;
@@ -78,11 +79,12 @@ public class Relocator {
 				if (pathRewriter != null) {
 					value = pathRewriter.rewrite(value);
 					if (value.startsWith("http"))
-						return fac.createAttribute(replace, getNewLocation(value, protocol, host, port));
+						return fac.createAttribute(replace, getNewLocation(value, protocol, host, port, contextPath));
 					return fac.createAttribute(replace, value);
 				}
 				if (value.startsWith("http"))
-					return fac.createAttribute(replace, getNewLocation(value, protocol, host, port));
+
+					return fac.createAttribute(replace, getNewLocation(value, protocol, host, port, contextPath));
 			}
 			return atr;
 		}
@@ -96,21 +98,23 @@ public class Relocator {
 		String rewrite(String path);
 	}
 
-	public Relocator(Writer w, String protocol, String host, int port, PathRewriter pathRewriter)
+	public Relocator(Writer w, String protocol, String host, int port, String contextPath, PathRewriter pathRewriter)
 			throws Exception {
 		this.writer = XMLOutputFactory.newInstance().createXMLEventWriter(w);
 		this.host = host;
 		this.port = port;
 		this.protocol = protocol;
+		this.contextPath = contextPath;
 		this.pathRewriter = pathRewriter;
 	}
 
 	public Relocator(OutputStreamWriter osw, String protocol, String host,
-			int port, PathRewriter pathRewriter) throws Exception {
+					 int port, String contextPath, PathRewriter pathRewriter) throws Exception {
 		this.writer = XMLOutputFactory.newInstance().createXMLEventWriter(osw);
 		this.host = host;
 		this.port = port;
 		this.protocol = protocol;
+		this.contextPath = contextPath;
 		this.pathRewriter = pathRewriter;
 	}
 
@@ -177,17 +181,17 @@ public class Relocator {
 	}
 
 	public static String getNewLocation(String addr, String protocol,
-			String host, int port) {
+			String host, int port, String contextPath) {
 		try {
 			URL oldURL = new URL(addr);
 			if (port == -1) {
-				return new URL(protocol, host, oldURL.getFile()).toString();
+				return new URL(protocol, host, contextPath + oldURL.getFile()).toString();
 			}
 			if ("http".equals(protocol) && port == 80)
 				port = -1;
 			if ("https".equals(protocol) && port == 443)
 				port = -1;
-			return new URL(protocol, host, port, oldURL.getFile()).toString();
+			return new URL(protocol, host, port, contextPath + oldURL.getFile()).toString();
 		} catch (MalformedURLException e) {
 			log.error("", e);
 		}

--- a/core/src/test/java/com/predic8/membrane/core/ws/relocator/RelocatorTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/ws/relocator/RelocatorTest.java
@@ -33,7 +33,7 @@ public class RelocatorTest extends TestCase {
 	protected void setUp() throws Exception {
 		relocator = new Relocator(new OutputStreamWriter(
 				NullOutputStream.NULL_OUTPUT_STREAM, Constants.UTF_8), "http", "localhost",
-				3000, null);
+				3000, null, null);
 		super.setUp();
 	}
 

--- a/core/src/test/java/com/predic8/membrane/core/ws/relocator/RelocatorWADLTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/ws/relocator/RelocatorWADLTest.java
@@ -57,7 +57,7 @@ public class RelocatorWADLTest extends TestCase {
 
 		writer = new StringWriter();
 
-		relocator = new Relocator(writer, "http", "localhost", 3000, null);
+		relocator = new Relocator(writer, "http", "localhost", 3000, null, null);
 		relocator.getRelocatingAttributes().put(
 				new QName(WADL_NS, "resources"), "base");
 		relocator.getRelocatingAttributes().put(new QName(WADL_NS, "include"),


### PR DESCRIPTION
soapProxy now works with different context paths (tested for war deployment)
