### PR TITLE
Add release and license badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 Membrane Service Proxy
 ======================
+[![GitHub release](https://img.shields.io/github/release/membrane/service-proxy.svg)](https://github.com/membrane/service-proxy/releases/latest)
+[![Hex.pm](https://img.shields.io/hexpm/l/plug.svg)](https://raw.githubusercontent.com/membrane/service-proxy/master/LICENSE)
 
 Check the [Repository at GitHub](https://github.com/membrane/service-proxy) for the latest source code. Read the [CHANGELOG](https://github.com/membrane/service-proxy/blob/master/distribution/router/CHANGELOG.txt) for recent changes.
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Membrane Service Proxy
 ======================
 [![GitHub release](https://img.shields.io/github/release/membrane/service-proxy.svg)](https://github.com/membrane/service-proxy/releases/latest)
-[![Hex.pm](https://img.shields.io/hexpm/l/plug.svg)](https://raw.githubusercontent.com/membrane/service-proxy/master/LICENSE)
+[![Hex.pm](https://img.shields.io/hexpm/l/plug.svg)](https://raw.githubusercontent.com/membrane/service-proxy/master/distribution/router/CHANGELOG.txt)
 
 Check the [Repository at GitHub](https://github.com/membrane/service-proxy) for the latest source code. Read the [CHANGELOG](https://github.com/membrane/service-proxy/blob/master/distribution/router/CHANGELOG.txt) for recent changes.
 


### PR DESCRIPTION
This PR adds two badges

* one to display and link to the latest release (the link is updated automatically when a new release is made)

[![GitHub release](https://img.shields.io/github/release/membrane/service-proxy.svg)](https://github.com/membrane/service-proxy/releases/latest)

* one to display and link to the project's license

[![Hex.pm](https://img.shields.io/hexpm/l/plug.svg)](https://raw.githubusercontent.com/membrane/service-proxy/master/distribution/router/CHANGELOG.txt)