### PR TITLE
remove query parameters from calledURI

### DIFF
--- a/core/src/main/java/com/predic8/membrane/core/rules/SwaggerProxyKey.java
+++ b/core/src/main/java/com/predic8/membrane/core/rules/SwaggerProxyKey.java
@@ -80,6 +80,11 @@ public class SwaggerProxyKey extends ServiceProxyKey {
 		final String IDENTIFIER = "[-_a-zA-Z0-9]+";
 		specName = specName.replaceAll("\\{" + IDENTIFIER + "\\}", IDENTIFIER);
 		String spec = swagger.getBasePath() + specName;
+		
+		if (calledURI.contains("?")){
+ 			calledURI = calledURI.substring(0,calledURI.indexOf("?"));
+		}
+		
 		return Pattern.matches(spec, calledURI);
 	}
 


### PR DESCRIPTION
Problem:

In some paths, there are query parameters (e.g. GET-/pet/findByStatus in http://petstore.swagger.io/v2/swagger.json). The method "pathTemplateMatch" doesn't remove those parameters and returns false so the RuleManager cannot found a rule. The system gives "Bad Request" errors.

Solution:

The query parameters are removed before calling the Pattern.matches method.