### PR TITLE
Changes to allow compilation for JDK1.6 target

### DIFF
--- a/core/src/main/java/com/predic8/membrane/core/http/AbstractBody.java
+++ b/core/src/main/java/com/predic8/membrane/core/http/AbstractBody.java
@@ -184,7 +184,17 @@ public abstract class AbstractBody {
 	protected abstract byte[] getRawLocal() throws IOException;
 
 	protected boolean hasRelevantObservers() {
-		return observers.stream().filter(messageObserver -> !(messageObserver instanceof NonRelevantBodyObserver)).collect(Collectors.toList()).size() > 0;
+		//return observers.stream().filter(messageObserver -> !(messageObserver instanceof NonRelevantBodyObserver)).collect(Collectors.toList()).size() > 0;
+                boolean hasRelevant = false;
+                for (MessageObserver o: observers)
+                {
+                    if ( ! (o instanceof NonRelevantBodyObserver))
+                    {
+                        hasRelevant = true;
+                        break;
+                    }
+                }
+                return hasRelevant;
 	}
 
 	/**

--- a/core/src/main/java/com/predic8/membrane/core/interceptor/MethodOverrideInterceptor.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/MethodOverrideInterceptor.java
@@ -35,9 +35,8 @@ public class MethodOverrideInterceptor extends AbstractInterceptor {
         if(methodHeader == null)
             return Outcome.CONTINUE;
 
-        switch(methodHeader){
-            case "GET": handleGet(exc);
-                        break;
+        if(methodHeader.equals("GET")){
+            handleGet(exc);
         }
 
         exc.getRequest().getHeader().removeFields(Header.X_HTTP_METHOD_OVERRIDE);

--- a/core/src/main/java/com/predic8/membrane/core/interceptor/administration/AdminPageBuilder.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/administration/AdminPageBuilder.java
@@ -72,7 +72,7 @@ public class AdminPageBuilder extends Html {
 	private final StringWriter writer;
 	private final String relativeRootPath;
 	private final boolean readOnly;
-	private HashMap<StatisticCollector, String> numberOfBackendConnections = new HashMap<>();
+	private HashMap<StatisticCollector, String> numberOfBackendConnections = new HashMap<StatisticCollector, String>();
 
 	static public String createHRef(String ctrl, String action, String query) {
 		return "/admin/"+ctrl+(action!=null?"/"+action:"")+(query!=null?"?"+query:"");
@@ -579,7 +579,7 @@ public class AdminPageBuilder extends Html {
 
 	private Map<String, StatisticCollector> getStatistics() {
 		Map<String, StatisticCollector> res = new TreeMap<String, StatisticCollector>();
-		HashMap<StatisticCollector,String> backendConnections = new HashMap<>();
+		HashMap<StatisticCollector,String> backendConnections = new HashMap<StatisticCollector,String>();
 		for (Rule r : router.getRuleManager().getRules()) {
 			if (!(r instanceof AbstractProxy)) continue;
 			StatisticCollector sc = new StatisticCollector(true);

--- a/core/src/main/java/com/predic8/membrane/core/interceptor/apimanagement/ApiManagementConfiguration.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/apimanagement/ApiManagementConfiguration.java
@@ -212,11 +212,23 @@ public class ApiManagementConfiguration {
     }
 
     private String parseString(Object obj, String defObj){
-        return StringToTypeConverter(obj,defObj, (value) -> {return value;});
+        //return StringToTypeConverter(obj,defObj, (value) -> {return value;});
+        return StringToTypeConverter(obj, defObj, new Function<String, String>() {
+            @Override
+            public String call(String value) {
+                return value;
+            }
+        });
     }
 
     private boolean parseBoolean(Object obj, Boolean defObj){
-        return StringToTypeConverter(obj,defObj,(value) -> {return Boolean.parseBoolean(value);});
+        //return StringToTypeConverter(obj,defObj,(value) -> {return Boolean.parseBoolean(value);});
+        return StringToTypeConverter(obj, defObj, new Function<String, Boolean>() {
+            @Override
+            public Boolean call(String value) {
+                return Boolean.parseBoolean(value);
+            }
+        });
     }
 
     private long getQuotaNumber(Object quotaSizeObj) {
@@ -235,6 +247,7 @@ public class ApiManagementConfiguration {
             }
         }
         if(quotaSymbolString.length() > 0) {
+            /*
             switch (quotaSymbolString) {
                 case "gb":
                 case "g": quotaNumber *= 1024;
@@ -245,12 +258,26 @@ public class ApiManagementConfiguration {
                 case "b":
                 default:
             }
+            */
+            if (quotaSymbolString.equals("gb") || quotaSymbolString.equals("g"))
+                quotaNumber *= 1024;
+            else if (quotaSymbolString.equals("mb") || quotaSymbolString.equals("m"))
+                quotaNumber *= 1024;
+            else if (quotaSymbolString.equals("kb") || quotaSymbolString.equals("k"))
+                quotaNumber *= 1024;
+            
         }
         return quotaNumber;
     }
 
     private int parseInteger(Object obj, int defaultValue){
-        return StringToTypeConverter(obj,defaultValue,(value) ->{return Integer.parseInt(value);});
+        //return StringToTypeConverter(obj,defaultValue,(value) ->{return Integer.parseInt(value);});
+        return StringToTypeConverter(obj, defaultValue, new Function<String, Integer>() {
+            @Override
+            public Integer call(String value) {
+                return Integer.parseInt(value);
+            }
+        });
     }
 
     private void parseAndConstructConfiguration(InputStream is) throws IOException {
@@ -278,7 +305,7 @@ public class ApiManagementConfiguration {
     }
 
     public HashSet<Policy> getUnauthenticatedPolicies() {
-        HashSet<Policy> result = new HashSet<>();
+        HashSet<Policy> result = new HashSet<Policy>();
         for(Policy p : getPolicies().values())
             if(p.isUnauthenticated())
                 result.add(p);

--- a/core/src/main/java/com/predic8/membrane/core/interceptor/apimanagement/quota/AMQuota.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/apimanagement/quota/AMQuota.java
@@ -59,7 +59,7 @@ public class AMQuota {
         public void run() {
             log.info("Getting new config");
             fillPolicyQuotas();
-            keyByteCounter = new ConcurrentHashMap<>();
+            keyByteCounter = new ConcurrentHashMap<String, ApiKeyByteCounter>();
         }
     };
 

--- a/core/src/main/java/com/predic8/membrane/core/interceptor/apimanagement/rateLimiter/AMRateLimiter.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/apimanagement/rateLimiter/AMRateLimiter.java
@@ -57,7 +57,7 @@ public class AMRateLimiter {
         @Override
         public void run() {
             log.info("Getting new config");
-            keyInformation = new ConcurrentHashMap<>();
+            keyInformation = new ConcurrentHashMap<String, ApiKeyRequestCounter>();
             fillPolicyCleanupTimes();
         }
     };

--- a/core/src/main/java/com/predic8/membrane/core/interceptor/authentication/session/CustomStatementJdbcUserDataProvider.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/authentication/session/CustomStatementJdbcUserDataProvider.java
@@ -87,7 +87,7 @@ public class CustomStatementJdbcUserDataProvider implements  UserDataProvider {
             ResultSet rs = preparedStatement.executeQuery();
             ResultSetMetaData rsmd = rs.getMetaData();
 
-            HashMap<String, String> result = new HashMap<>();
+            HashMap<String, String> result = new HashMap<String, String>();
             if (!rs.next())
                 throw new NoSuchElementException();
             result.put(sqlResultAttribute, rs.getObject(1).toString());

--- a/core/src/main/java/com/predic8/membrane/core/interceptor/authentication/session/JdbcUserDataProvider.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/authentication/session/JdbcUserDataProvider.java
@@ -121,7 +121,7 @@ public class JdbcUserDataProvider implements  UserDataProvider {
             ResultSet rs = preparedStatement.executeQuery();
             ResultSetMetaData rsmd = rs.getMetaData();
 
-            result = new HashMap<>();
+            result = new HashMap<String,String>();
             while(rs.next()){
                 for(int i = 1; i <= rsmd.getColumnCount();i++)
                     result.put(rsmd.getColumnName(i),rs.getObject(i).toString());

--- a/core/src/main/java/com/predic8/membrane/core/interceptor/javascript/JavascriptInterceptor.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/javascript/JavascriptInterceptor.java
@@ -112,7 +112,7 @@ public class JavascriptInterceptor extends AbstractInterceptor {
     }
 
     private HashMap<String, Object> getJavascriptTypesForClasses(HashMap<String, Object> classes) {
-        HashMap<String, Object> result = new HashMap<>();
+        HashMap<String, Object> result = new HashMap<String, Object>();
         for(Object clazz : classes.values()){
             Class<?> clazzz = (Class<?>) clazz;
             String scriptSrc = clazzz.getSimpleName() + ".static;";
@@ -133,7 +133,7 @@ public class JavascriptInterceptor extends AbstractInterceptor {
 
     private HashMap<String, Object> getHttpPackageClasses() throws IOException, ClassNotFoundException {
         String httpPackage = "com.predic8.membrane.core.http";
-        HashMap<String, Object> result = new HashMap<>();
+        HashMap<String, Object> result = new HashMap<String, Object>();
         List<Class<?>> classes = ClassFinder.find(router.getBeanFactory().getClassLoader(), httpPackage);
         for(Class c : classes) {
             if(c.getPackage().getName().equals(httpPackage) && !c.getSimpleName().isEmpty())

--- a/core/src/main/java/com/predic8/membrane/core/interceptor/oauth2/CookieUtil.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/oauth2/CookieUtil.java
@@ -38,7 +38,7 @@ public class CookieUtil {
     }
 
     private static ArrayList<String> removeOwnCookieNameFromCookieHeader(String ownCookieName, String[] cookies) {
-        ArrayList<String> newCookies = new ArrayList<>();
+        ArrayList<String> newCookies = new ArrayList<String>();
         for(String cookie : cookies)
             if(!cookie.trim().startsWith(ownCookieName))
                 newCookies.add(cookie.trim());

--- a/core/src/main/java/com/predic8/membrane/core/interceptor/oauth2/OAuth2ResourceInterceptor.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/oauth2/OAuth2ResourceInterceptor.java
@@ -77,7 +77,7 @@ public class OAuth2ResourceInterceptor extends AbstractInterceptor {
 
     private int revalidateTokenAfter = -1;
 
-    private ConcurrentHashMap<String,String> stateToOriginalUrl = new ConcurrentHashMap<>();
+    private ConcurrentHashMap<String,String> stateToOriginalUrl = new ConcurrentHashMap<String,String>();
 
     private WebServerInterceptor wsi;
     private URIFactory uriFactory;
@@ -381,7 +381,7 @@ public class OAuth2ResourceInterceptor extends AbstractInterceptor {
                 if(session.getUserAttributes().containsKey(ParamNames.STATE))
                     state = session.getUserAttributes().get(ParamNames.STATE) + " " + state;
                 if(!session.isPreAuthorized() || !session.isAuthorized())
-                    session.preAuthorize("",new HashMap<>());
+                    session.preAuthorize("",new HashMap<String,String>());
                 session.getUserAttributes().put(ParamNames.STATE,state);
             }
         } else {

--- a/core/src/main/java/com/predic8/membrane/core/interceptor/oauth2/parameter/ClaimsParameter.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/oauth2/parameter/ClaimsParameter.java
@@ -119,7 +119,7 @@ public class ClaimsParameter {
 
     private Map<String,Object> getObject(String objectName){
         if(cleanedJson == null || cleanedJson.get(objectName) == null)
-            return new HashMap<>();
+            return new HashMap<String,Object>();
         return (Map<String, Object>) cleanedJson.get(objectName);
     }
 

--- a/core/src/main/java/com/predic8/membrane/core/interceptor/server/WebServerInterceptor.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/server/WebServerInterceptor.java
@@ -30,8 +30,9 @@ import org.springframework.beans.factory.annotation.Required;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.nio.file.Path;
-import java.nio.file.Paths;
+//import java.nio.file.Path;
+//import java.nio.file.Paths;
+import org.apache.commons.io.FilenameUtils;
 import java.util.Collections;
 import java.util.List;
 import java.util.regex.Pattern;
@@ -215,9 +216,11 @@ public class WebServerInterceptor extends AbstractInterceptor {
 
     private String getAbsolutePathWithSchemePrefix(String path) {
         try {
-            Path p = Paths.get(path);
-            if (p.isAbsolute())
-                return p.toUri().toString();
+            if (FilenameUtils.getPrefixLength(path) != 0)
+                return "file://"+path;
+            //Path p = Paths.get(path);
+            //if (p.isAbsolute())
+            //    return p.toUri().toString();
         } catch (Exception ignored) {
         }
 

--- a/core/src/main/java/com/predic8/membrane/core/interceptor/swagger/SwaggerRewriterInterceptor.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/swagger/SwaggerRewriterInterceptor.java
@@ -16,8 +16,8 @@ package com.predic8.membrane.core.interceptor.swagger;
 
 import java.net.URL;
 import java.nio.charset.Charset;
-import java.nio.file.Files;
-import java.nio.file.Paths;
+//import java.nio.file.Files;
+//import java.nio.file.Paths;
 import java.util.List;
 import java.util.regex.Pattern;
 

--- a/core/src/main/java/com/predic8/membrane/core/interceptor/tunnel/WebSocketInterceptor.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/tunnel/WebSocketInterceptor.java
@@ -38,7 +38,7 @@ import java.util.List;
 public class WebSocketInterceptor extends AbstractInterceptor {
 	private String url;
 	private String pathQuery;
-	private List<WebSocketInterceptorInterface> interceptors = new ArrayList<>();
+	private List<WebSocketInterceptorInterface> interceptors = new ArrayList<WebSocketInterceptorInterface>();
 
 	@Override
 	public void init(Router router) throws Exception {

--- a/core/src/main/java/com/predic8/membrane/core/transport/http/ByteStreamLogging.java
+++ b/core/src/main/java/com/predic8/membrane/core/transport/http/ByteStreamLogging.java
@@ -46,7 +46,7 @@ public class ByteStreamLogging {
         log.info(sb.toString());
     }
 
-    public static OutputStream wrapConnectionOutputStream(Connection con, String name) {
+    public static OutputStream wrapConnectionOutputStream(final Connection con, final String name) {
         return new OutputStream() {
             @Override
             public void write(int b) throws IOException {
@@ -78,7 +78,7 @@ public class ByteStreamLogging {
         };
     }
 
-    public static InputStream wrapConnectionInputStream(Connection con, String name) {
+    public static InputStream wrapConnectionInputStream(final Connection con, final String name) {
         return new InputStream() {
             @Override
             public int read() throws IOException {

--- a/core/src/main/java/com/predic8/membrane/core/transport/ssl/StaticSSLContext.java
+++ b/core/src/main/java/com/predic8/membrane/core/transport/ssl/StaticSSLContext.java
@@ -320,7 +320,7 @@ public class StaticSSLContext extends SSLContext {
             sniServerName = defaultHost;
 
         SNIHostName name = new SNIHostName(sniServerName.getBytes()); // mvn complains here when not putting in "bytes" even though there is a constructor for "string"
-        List<SNIServerName> serverNames = new ArrayList<>(1);
+        List<SNIServerName> serverNames = new ArrayList<SNIServerName>(1);
         serverNames.add(name);
 
         SSLParameters params = ssls.getSSLParameters();

--- a/core/src/main/java/com/predic8/membrane/core/transport/ws/interceptors/WebSocketStompReassembler.java
+++ b/core/src/main/java/com/predic8/membrane/core/transport/ws/interceptors/WebSocketStompReassembler.java
@@ -36,7 +36,7 @@ import java.util.List;
 @MCElement(name = "wsStompReassembler")
 public class WebSocketStompReassembler implements WebSocketInterceptorInterface {
 
-    List<Interceptor> interceptors = new ArrayList<>();
+    List<Interceptor> interceptors = new ArrayList<Interceptor>();
 
     @Override
     public void init(Router router) throws Exception {

--- a/core/src/test/java/com/predic8/membrane/core/cloud/etcd/EtcdRequestTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/cloud/etcd/EtcdRequestTest.java
@@ -14,18 +14,22 @@
 
 package com.predic8.membrane.core.cloud.etcd;
 
+import java.io.File;
 import org.junit.Test;
 
 import java.io.IOException;
 import java.nio.charset.Charset;
-import java.nio.file.Files;
-import java.nio.file.Paths;
+import java.util.Scanner;
+//import java.nio.file.Files;
+//import java.nio.file.Paths;
 
 public class EtcdRequestTest {
 
     @Test
     public void testFillEtcdWithYaml() throws IOException {
-        String source =  new String(Files.readAllBytes(Paths.get(System.getProperty("user.dir") + "\\src\\test\\resources\\apimanagement\\api.yaml")), Charset.defaultCharset());
+        String path = System.getProperty("user.dir") + "\\src\\test\\resources\\apimanagement\\api.yaml";
+        String source = new Scanner(new File(path)).useDelimiter("\\Z").next();
+        //String source =  new String(Files.readAllBytes(Paths.get(System.getProperty("user.dir") + "\\src\\test\\resources\\apimanagement\\api.yaml")), Charset.defaultCharset());
 
         try {
             EtcdResponse respPutYaml = EtcdRequest.create("http://localhost:4001", "/amc", "").setValue("file", source).sendRequest();

--- a/core/src/test/java/com/predic8/membrane/core/interceptor/apimanagement/AMQuotaInterceptorTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/interceptor/apimanagement/AMQuotaInterceptorTest.java
@@ -25,8 +25,8 @@ import org.junit.Test;
 
 import java.io.IOException;
 import java.nio.charset.Charset;
-import java.nio.file.Files;
-import java.nio.file.Paths;
+//import java.nio.file.Files;
+//import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.concurrent.atomic.AtomicInteger;
 

--- a/core/src/test/java/com/predic8/membrane/core/interceptor/apimanagement/AMRateLimitInterceptorTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/interceptor/apimanagement/AMRateLimitInterceptorTest.java
@@ -24,8 +24,8 @@ import org.junit.Test;
 
 import java.io.InputStream;
 import java.nio.charset.Charset;
-import java.nio.file.Files;
-import java.nio.file.Paths;
+//import java.nio.file.Files;
+//import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.concurrent.atomic.AtomicInteger;
 

--- a/core/src/test/java/com/predic8/membrane/core/interceptor/apimanagement/ApiManagementConfigurationTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/interceptor/apimanagement/ApiManagementConfigurationTest.java
@@ -14,20 +14,25 @@
 package com.predic8.membrane.core.interceptor.apimanagement;
 
 import com.predic8.membrane.core.interceptor.apimanagement.policy.Policy;
+import java.io.File;
 import org.apache.commons.io.IOUtils;
 import org.junit.Test;
 
 import java.io.InputStream;
 import java.nio.charset.Charset;
-import java.nio.file.Files;
-import java.nio.file.Paths;
+//import java.nio.file.Files;
+//import java.nio.file.Paths;
 import java.util.Map;
+import java.util.Scanner;
 
 public class ApiManagementConfigurationTest {
 
     @Test
     public void testParseYaml() throws Exception {
-        String source =  new String(Files.readAllBytes(Paths.get(System.getProperty("user.dir") + "\\src\\test\\resources\\apimanagement\\api.yaml")), Charset.defaultCharset());
+        
+        String path = System.getProperty("user.dir") + "\\src\\test\\resources\\apimanagement\\api.yaml";
+        String source = new Scanner(new File(path)).useDelimiter("\\Z").next();
+        //String source =  new String(Files.readAllBytes(Paths.get(System.getProperty("user.dir") + "\\src\\test\\resources\\apimanagement\\api.yaml")), Charset.defaultCharset());
 
         ApiManagementConfiguration conf = new ApiManagementConfiguration();
         conf.setLocation(source);

--- a/core/src/test/java/com/predic8/membrane/core/interceptor/apimanagement/ApiManagementInterceptorTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/interceptor/apimanagement/ApiManagementInterceptorTest.java
@@ -28,8 +28,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URISyntaxException;
 import java.nio.charset.Charset;
-import java.nio.file.Files;
-import java.nio.file.Paths;
+//import java.nio.file.Files;
+//import java.nio.file.Paths;
 
 public class ApiManagementInterceptorTest {
 

--- a/core/src/test/java/com/predic8/membrane/core/rules/ProxySSLTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/rules/ProxySSLTest.java
@@ -78,7 +78,7 @@ public class ProxySSLTest {
         backend.start();
 
         // Step 2: put a proxy in front of it
-        AtomicInteger proxyCounter = new AtomicInteger();
+        final AtomicInteger proxyCounter = new AtomicInteger();
 
         Router proxyRouter = new Router();
         proxyRouter.setHotDeploy(false);

--- a/pom.xml
+++ b/pom.xml
@@ -77,8 +77,8 @@
 		<project.build.sourceEncoding>ISO-8859-1</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>ISO-8859-1</project.reporting.outputEncoding>
 		<gpg.keyname>5B8A65F6</gpg.keyname>
-		<javac.source>1.8</javac.source>
-		<javac.target>1.8</javac.target>
+		<javac.source>1.6</javac.source>
+		<javac.target>1.6</javac.target>
 		<jackson.version>2.8.3</jackson.version> <!-- This version is used by google-http-client-jackson2 -->
 		<spring.version>4.2.3.RELEASE</spring.version>
 		<jaxws.version>2.2.10</jaxws.version>


### PR DESCRIPTION
Hello,
these  small changes allow to use membrane with target jdk 1.6 (useful for legacy hardware supporting only Red Hat 4, which can run jdk 1.6 at most) - it would be nice to keep everything jdk1.6 compatible like spring boot tries to do.