### PR TITLE
Replace \\ with / in tests to allow tests to run under linux

### DIFF
--- a/core/src/main/java/com/predic8/membrane/core/interceptor/oauth2/authorizationservice/MembraneAuthorizationService.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/oauth2/authorizationservice/MembraneAuthorizationService.java
@@ -63,6 +63,12 @@ public class MembraneAuthorizationService extends AuthorizationService {
             dynamicRegistration.init(router);
             supportsDynamicRegistration = true;
         }
+        router.registerForDelayedInitialization(this);
+        //init2();
+
+    }
+
+    public void init2() throws Exception {
         try {
             String[] urls = src.split(Pattern.quote(" "));
             if(urls.length == 1) {

--- a/core/src/test/java/com/predic8/membrane/core/cloud/etcd/EtcdRequestTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/cloud/etcd/EtcdRequestTest.java
@@ -25,7 +25,7 @@ public class EtcdRequestTest {
 
     @Test
     public void testFillEtcdWithYaml() throws IOException {
-        String source =  new String(Files.readAllBytes(Paths.get(System.getProperty("user.dir") + "\\src\\test\\resources\\apimanagement\\api.yaml")), Charset.defaultCharset());
+        String source =  new String(Files.readAllBytes(Paths.get(System.getProperty("user.dir") + "/src/test/resources/apimanagement/api.yaml")), Charset.defaultCharset());
 
         try {
             EtcdResponse respPutYaml = EtcdRequest.create("http://localhost:4001", "/amc", "").setValue("file", source).sendRequest();

--- a/core/src/test/java/com/predic8/membrane/core/interceptor/apimanagement/AMQuotaInterceptorTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/interceptor/apimanagement/AMQuotaInterceptorTest.java
@@ -42,7 +42,7 @@ public class AMQuotaInterceptorTest {
         exc.setRule(new ServiceProxy());
         exc.getRule().setName("junit API");
 
-        ApiManagementConfiguration amc = new ApiManagementConfiguration(System.getProperty("user.dir") , "src\\test\\resources\\apimanagement\\api.yaml");
+        ApiManagementConfiguration amc = new ApiManagementConfiguration(System.getProperty("user.dir") , "src/test/resources/apimanagement/api.yaml");
 
         long reqSize = exc.getRequest().getHeader().toString().getBytes().length+exc.getRequest().getHeader().getContentLength();
         long respSize = exc.getResponse().getHeader().toString().getBytes().length+exc.getResponse().getHeader().getContentLength();

--- a/core/src/test/java/com/predic8/membrane/core/interceptor/apimanagement/AMRateLimitInterceptorTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/interceptor/apimanagement/AMRateLimitInterceptorTest.java
@@ -44,7 +44,7 @@ public class AMRateLimitInterceptorTest {
         exc.getRule().setName("junit API");
 
         final AMRateLimiter rli = new AMRateLimiter();
-        ApiManagementConfiguration amc = new ApiManagementConfiguration(System.getProperty("user.dir") , "src\\test\\resources\\apimanagement\\api.yaml");
+        ApiManagementConfiguration amc = new ApiManagementConfiguration(System.getProperty("user.dir") , "src/test/resources/apimanagement/api.yaml");
         rli.setAmc(amc);
 
         ArrayList<Thread> threads = new ArrayList<Thread>();

--- a/core/src/test/java/com/predic8/membrane/core/interceptor/apimanagement/ApiManagementConfigurationTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/interceptor/apimanagement/ApiManagementConfigurationTest.java
@@ -27,7 +27,7 @@ public class ApiManagementConfigurationTest {
 
     @Test
     public void testParseYaml() throws Exception {
-        String source =  new String(Files.readAllBytes(Paths.get(System.getProperty("user.dir") + "\\src\\test\\resources\\apimanagement\\api.yaml")), Charset.defaultCharset());
+        String source =  new String(Files.readAllBytes(Paths.get(System.getProperty("user.dir") + "/src/test/resources/apimanagement/api.yaml")), Charset.defaultCharset());
 
         ApiManagementConfiguration conf = new ApiManagementConfiguration();
         conf.setLocation(source);

--- a/core/src/test/java/com/predic8/membrane/core/interceptor/apimanagement/ApiManagementInterceptorTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/interceptor/apimanagement/ApiManagementInterceptorTest.java
@@ -52,7 +52,7 @@ public class ApiManagementInterceptorTest {
         //hd.removeFields(headerName);
         exc.setRequest(new Request.Builder().get("").header(hd).build());
 
-        String source =  new String(Files.readAllBytes(Paths.get(System.getProperty("user.dir") + "\\src\\test\\resources\\apimanagement\\api.yaml")), Charset.defaultCharset());
+        String source =  new String(Files.readAllBytes(Paths.get(System.getProperty("user.dir") + "/src/test/resources/apimanagement/api.yaml")), Charset.defaultCharset());
         InputStream in = IOUtils.toInputStream(source, Charset.defaultCharset());
 
         ApiManagementInterceptor ami = new ApiManagementInterceptor();

--- a/core/src/test/java/com/predic8/membrane/core/interceptor/oauth2/AuthWithSessionRequestTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/interceptor/oauth2/AuthWithSessionRequestTest.java
@@ -48,6 +48,6 @@ public class AuthWithSessionRequestTest extends RequestParameterizedTest {
     }
 
     private static Object[] testPromptEqualsLogin() {
-        return new Object[]{"testPromptEqualsLogin",addValueToRequestUri("prompt=login"),303,getBool(true),responseContainsValueInLocationHeader("/oauth2/auth")};
+        return new Object[]{"testPromptEqualsLogin",addValueToRequestUri("prompt=login"),307,getBool(true),responseContainsValueInLocationHeader("/oauth2/auth")};
     }
 }

--- a/core/src/test/java/com/predic8/membrane/core/interceptor/oauth2/AuthWithoutSessionOpenidRequestTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/interceptor/oauth2/AuthWithoutSessionOpenidRequestTest.java
@@ -40,11 +40,11 @@ public class AuthWithoutSessionOpenidRequestTest extends RequestParameterizedTes
     }
 
     private static Object[] testHasClaimsButIsNotOpenid() {
-        return new Object[]{"testHasClaimsButIsNotOpenid", replaceValueFromRequestUri("scope=openid","scope=profile"),303, getBool(true), sessionHasNoClaimsParam()};
+        return new Object[]{"testHasClaimsButIsNotOpenid", replaceValueFromRequestUri("scope=openid","scope=profile"),307, getBool(true), sessionHasNoClaimsParam()};
     }
 
     private static Object[] testOpenidScopeButIsTokenResponseType() {
-        return new Object[]{"testOpenidScopeButIsTokenResponseType",replaceValueFromRequestUri("response_type=code","response_type=token"),303,getBool(true),responseContainsValueInLocationHeader("error=invalid_request")};
+        return new Object[]{"testOpenidScopeButIsTokenResponseType",replaceValueFromRequestUri("response_type=code","response_type=token"),307,getBool(true),responseContainsValueInLocationHeader("error=invalid_request")};
     }
 
     private static Callable<Object> sessionHasNoClaimsParam() {

--- a/core/src/test/java/com/predic8/membrane/core/interceptor/oauth2/AuthWithoutSessionRequestTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/interceptor/oauth2/AuthWithoutSessionRequestTest.java
@@ -47,15 +47,15 @@ public class AuthWithoutSessionRequestTest extends RequestParameterizedTest{
     }
 
     private static Object[] testPromptIsNone() {
-        return new Object[]{"testPromptIsNone",addValueToRequestUri("prompt=none"),303,getBool(true),responseContainsValueInLocationHeader("error=login_required")};
+        return new Object[]{"testPromptIsNone",addValueToRequestUri("prompt=none"),307,getBool(true),responseContainsValueInLocationHeader("error=login_required")};
     }
 
     private static Object[] testEmptyScopeList() {
-        return new Object[]{"testEmptyScopeList",replaceValueFromRequestUri("scope=profile","scope=123456789"),303,getBool(true),responseContainsValueInLocationHeader("error=invalid_scope")};
+        return new Object[]{"testEmptyScopeList",replaceValueFromRequestUri("scope=profile","scope=123456789"),307,getBool(true),responseContainsValueInLocationHeader("error=invalid_scope")};
     }
 
     private static Object[] testUnsupportedResponseType() {
-        return new Object[]{"testUnsupportedResponseType",replaceValueFromRequestUri("response_type=code","response_type=code123456789"),303,getBool(true),responseContainsValueInLocationHeader("error=unsupported_response_type")};
+        return new Object[]{"testUnsupportedResponseType",replaceValueFromRequestUri("response_type=code","response_type=code123456789"),307,getBool(true),responseContainsValueInLocationHeader("error=unsupported_response_type")};
     }
 
     private static Object[] testRedirectUriNotEqauls() {
@@ -67,7 +67,7 @@ public class AuthWithoutSessionRequestTest extends RequestParameterizedTest{
     }
 
     private static Object[] testResponseTypeMissing() {
-        return new Object[]{"testResponseTypeMissing",removeValueFromRequestUri("&response_type=code"),303,getBool(true),responseContainsValueInLocationHeader("error=invalid_request")};
+        return new Object[]{"testResponseTypeMissing",removeValueFromRequestUri("&response_type=code"),307,getBool(true),responseContainsValueInLocationHeader("error=invalid_request")};
     }
 
     private static Object[] testRedirectUriMissing() {
@@ -83,6 +83,6 @@ public class AuthWithoutSessionRequestTest extends RequestParameterizedTest{
     }
 
     private static Object[] testScopeMissing() {
-        return new Object[]{"testScopeMissing",removeValueFromRequestUri("&scope=profile"),303,getBool(true),responseContainsValueInLocationHeader("error=invalid_request")};
+        return new Object[]{"testScopeMissing",removeValueFromRequestUri("&scope=profile"),307,getBool(true),responseContainsValueInLocationHeader("error=invalid_request")};
     }
 }

--- a/core/src/test/java/com/predic8/membrane/core/interceptor/oauth2/EmptyEndpointOpenidTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/interceptor/oauth2/EmptyEndpointOpenidTest.java
@@ -42,7 +42,7 @@ public class EmptyEndpointOpenidTest extends RequestParameterizedTest{
     }
 
     private static Object[] testIdTokenTokenResponse() {
-        return new Object[] {"testIdTokenTokenResponse", modifySessionToIdTokenTokenResponseType(),303,getBool(true),responseContainsValueInLocationHeader("id_token=")};
+        return new Object[] {"testIdTokenTokenResponse", modifySessionToIdTokenTokenResponseType(),307,getBool(true),responseContainsValueInLocationHeader("id_token=")};
     }
 
     private static Object[] testConsentNotGiven() {

--- a/core/src/test/java/com/predic8/membrane/core/interceptor/oauth2/EmptyEndpointTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/interceptor/oauth2/EmptyEndpointTest.java
@@ -45,11 +45,11 @@ public class EmptyEndpointTest extends RequestParameterizedTest{
     }
 
     private static Object[] testTokenResponse() {
-        return new Object[]{"testTokenResponse", modifySessionToTokenResponseType(),303,getBool(true),responseContainsValueInLocationHeader("token=")};
+        return new Object[]{"testTokenResponse", modifySessionToTokenResponseType(),307,getBool(true),responseContainsValueInLocationHeader("token=")};
     }
 
     private static Object[] testCodeResponse() {
-        return new Object[]{"testCodeResponse", modifySessionToCodeResponseType(),303,getBool(true),responseContainsValueInLocationHeader("code=")};
+        return new Object[]{"testCodeResponse", modifySessionToCodeResponseType(),307,getBool(true),responseContainsValueInLocationHeader("code=")};
     }
 
     private static Callable<Object> modifySessionToCodeResponseType() {

--- a/core/src/test/java/com/predic8/membrane/core/interceptor/oauth2/OAuth2AuthorizationServerInterceptorBase.java
+++ b/core/src/test/java/com/predic8/membrane/core/interceptor/oauth2/OAuth2AuthorizationServerInterceptorBase.java
@@ -269,8 +269,9 @@ public abstract class OAuth2AuthorizationServerInterceptorBase {
         mas = new MembraneAuthorizationService();
         mas.setClientId("abc");
         mas.setClientSecret("def");
-        mas.setSrc(System.getProperty("user.dir") + "\\src\\test\\resources\\oauth2");
+        mas.setSrc(System.getProperty("user.dir") + "/src/test/resources/oauth2");
         mas.init(router);
+        mas.init2();
     }
 
     private void initOasi() throws Exception {
@@ -283,8 +284,8 @@ public abstract class OAuth2AuthorizationServerInterceptorBase {
     }
 
     private void setOasiProperties() {
-        oasi.setLocation("src\\test\\resources\\oauth2\\loginDialog\\dialog");
-        oasi.setConsentFile("src\\test\\resources\\oauth2\\consentFile.json");
+        oasi.setLocation("src/test/resources/oauth2/loginDialog/dialog");
+        oasi.setConsentFile("src/test/resources/oauth2/consentFile.json");
         oasi.setPath("/login/");
         oasi.setIssuer("http://Localhost:2001");
     }

--- a/core/src/test/java/com/predic8/membrane/core/interceptor/oauth2/OAuth2AuthorizationServerInterceptorNormalTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/interceptor/oauth2/OAuth2AuthorizationServerInterceptorNormalTest.java
@@ -65,11 +65,11 @@ public class OAuth2AuthorizationServerInterceptorNormalTest extends OAuth2Author
     }
 
     private static Object[] testGoodGrantedAuthCode() throws Exception {
-        return new Object[]{"testGoodGrantedAuthCode", runUntilGoodAuthRequest(), getMockEmptyEndpointRequest(), 303, getCodeFromResponse()};
+        return new Object[]{"testGoodGrantedAuthCode", runUntilGoodAuthRequest(), getMockEmptyEndpointRequest(), 307, getCodeFromResponse()};
     }
 
     private static Object[] testGoodAuthRequest() throws Exception {
-        return new Object[]{"testGoodAuthRequest", noPreprocessing(), getMockAuthRequestExchange(),303, loginAsJohn()};
+        return new Object[]{"testGoodAuthRequest", noPreprocessing(), getMockAuthRequestExchange(),307, loginAsJohn()};
     }
 
     private static Object[] testBadRequest() throws Exception {

--- a/core/src/test/java/com/predic8/membrane/core/interceptor/oauth2/OAuth2AuthorizationServerInterceptorOpenidTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/interceptor/oauth2/OAuth2AuthorizationServerInterceptorOpenidTest.java
@@ -61,11 +61,11 @@ public class OAuth2AuthorizationServerInterceptorOpenidTest extends OAuth2Author
     }
 
     private static Object[] testGoodGrantedAuthCode() throws Exception {
-        return new Object[]{"testGoodGrantedAuthCode", runUntilGoodAuthOpenidRequest(), getMockEmptyEndpointRequest(), 303, getCodeFromResponse()};
+        return new Object[]{"testGoodGrantedAuthCode", runUntilGoodAuthOpenidRequest(), getMockEmptyEndpointRequest(), 307, getCodeFromResponse()};
     }
 
     private static Object[] testGoodAuthRequest() {
-        return new Object[]{"testGoodAuthRequest", noPreprocessing(), getMockAuthOpenidRequestExchange(),303, loginAsJohnOpenid()};
+        return new Object[]{"testGoodAuthRequest", noPreprocessing(), getMockAuthOpenidRequestExchange(),307, loginAsJohnOpenid()};
     }
 
     private static Consumer<Exchange> loginAsJohnOpenid() {


### PR DESCRIPTION
I could not executed the tests under linux because we don't have backslashes in our path.

I basically only replaced the escaped backslashes with slashes in the tests to allow for tests to run under linux properly.