### PR TITLE
Replacing \\ with / in Unit Tests.

### DIFF
--- a/core/src/test/java/com/predic8/membrane/core/cloud/etcd/EtcdRequestTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/cloud/etcd/EtcdRequestTest.java
@@ -25,7 +25,7 @@ public class EtcdRequestTest {
 
     @Test
     public void testFillEtcdWithYaml() throws IOException {
-        String source =  new String(Files.readAllBytes(Paths.get(System.getProperty("user.dir") + "\\src\\test\\resources\\apimanagement\\api.yaml")), Charset.defaultCharset());
+        String source =  new String(Files.readAllBytes(Paths.get(System.getProperty("user.dir") + "/src/test/resources/apimanagement/api.yaml")), Charset.defaultCharset());
 
         try {
             EtcdResponse respPutYaml = EtcdRequest.create("http://localhost:4001", "/amc", "").setValue("file", source).sendRequest();

--- a/core/src/test/java/com/predic8/membrane/core/interceptor/apimanagement/AMQuotaInterceptorTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/interceptor/apimanagement/AMQuotaInterceptorTest.java
@@ -42,7 +42,7 @@ public class AMQuotaInterceptorTest {
         exc.setRule(new ServiceProxy());
         exc.getRule().setName("junit API");
 
-        ApiManagementConfiguration amc = new ApiManagementConfiguration(System.getProperty("user.dir") , "src\\test\\resources\\apimanagement\\api.yaml");
+        ApiManagementConfiguration amc = new ApiManagementConfiguration(System.getProperty("user.dir") , "src/test/resources/apimanagement/api.yaml");
 
         long reqSize = exc.getRequest().getHeader().toString().getBytes().length+exc.getRequest().getHeader().getContentLength();
         long respSize = exc.getResponse().getHeader().toString().getBytes().length+exc.getResponse().getHeader().getContentLength();

--- a/core/src/test/java/com/predic8/membrane/core/interceptor/apimanagement/AMRateLimitInterceptorTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/interceptor/apimanagement/AMRateLimitInterceptorTest.java
@@ -44,7 +44,7 @@ public class AMRateLimitInterceptorTest {
         exc.getRule().setName("junit API");
 
         final AMRateLimiter rli = new AMRateLimiter();
-        ApiManagementConfiguration amc = new ApiManagementConfiguration(System.getProperty("user.dir") , "src\\test\\resources\\apimanagement\\api.yaml");
+        ApiManagementConfiguration amc = new ApiManagementConfiguration(System.getProperty("user.dir") , "src/test/resources/apimanagement/api.yaml");
         rli.setAmc(amc);
 
         ArrayList<Thread> threads = new ArrayList<Thread>();

--- a/core/src/test/java/com/predic8/membrane/core/interceptor/apimanagement/ApiManagementConfigurationTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/interceptor/apimanagement/ApiManagementConfigurationTest.java
@@ -27,7 +27,7 @@ public class ApiManagementConfigurationTest {
 
     @Test
     public void testParseYaml() throws Exception {
-        String source =  new String(Files.readAllBytes(Paths.get(System.getProperty("user.dir") + "\\src\\test\\resources\\apimanagement\\api.yaml")), Charset.defaultCharset());
+        String source =  new String(Files.readAllBytes(Paths.get(System.getProperty("user.dir") + "/src/test/resources/apimanagement/api.yaml")), Charset.defaultCharset());
 
         ApiManagementConfiguration conf = new ApiManagementConfiguration();
         conf.setLocation(source);

--- a/core/src/test/java/com/predic8/membrane/core/interceptor/apimanagement/ApiManagementInterceptorTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/interceptor/apimanagement/ApiManagementInterceptorTest.java
@@ -52,7 +52,7 @@ public class ApiManagementInterceptorTest {
         //hd.removeFields(headerName);
         exc.setRequest(new Request.Builder().get("").header(hd).build());
 
-        String source =  new String(Files.readAllBytes(Paths.get(System.getProperty("user.dir") + "\\src\\test\\resources\\apimanagement\\api.yaml")), Charset.defaultCharset());
+        String source =  new String(Files.readAllBytes(Paths.get(System.getProperty("user.dir") + "/src/test/resources/apimanagement/api.yaml")), Charset.defaultCharset());
         InputStream in = IOUtils.toInputStream(source, Charset.defaultCharset());
 
         ApiManagementInterceptor ami = new ApiManagementInterceptor();

--- a/core/src/test/java/com/predic8/membrane/core/interceptor/oauth2/OAuth2AuthorizationServerInterceptorBase.java
+++ b/core/src/test/java/com/predic8/membrane/core/interceptor/oauth2/OAuth2AuthorizationServerInterceptorBase.java
@@ -269,8 +269,9 @@ public abstract class OAuth2AuthorizationServerInterceptorBase {
         mas = new MembraneAuthorizationService();
         mas.setClientId("abc");
         mas.setClientSecret("def");
-        mas.setSrc(System.getProperty("user.dir") + "\\src\\test\\resources\\oauth2");
+        mas.setSrc(System.getProperty("user.dir") + "/src/test/resources/oauth2");
         mas.init(router);
+        mas.init2();
     }
 
     private void initOasi() throws Exception {
@@ -283,8 +284,8 @@ public abstract class OAuth2AuthorizationServerInterceptorBase {
     }
 
     private void setOasiProperties() {
-        oasi.setLocation("src\\test\\resources\\oauth2\\loginDialog\\dialog");
-        oasi.setConsentFile("src\\test\\resources\\oauth2\\consentFile.json");
+        oasi.setLocation("src/test/resources/oauth2/loginDialog/dialog");
+        oasi.setConsentFile("src/test/resources/oauth2/consentFile.json");
         oasi.setPath("/login/");
         oasi.setIssuer("http://Localhost:2001");
     }


### PR DESCRIPTION
I could not executed the tests under linux because we don't have backslashes in our path.

I basically only replaced the escaped backslashes with slashes in the tests to allow for tests to run under linux properly.