### PR TITLE
Delaying start of OAuth2 Authenticator Services

### DIFF
--- a/core/src/main/java/com/predic8/membrane/core/interceptor/oauth2/authorizationservice/MembraneAuthorizationService.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/oauth2/authorizationservice/MembraneAuthorizationService.java
@@ -63,6 +63,12 @@ public class MembraneAuthorizationService extends AuthorizationService {
             dynamicRegistration.init(router);
             supportsDynamicRegistration = true;
         }
+        router.registerForDelayedInitialization(this);
+        //init2();
+
+    }
+
+    public void init2() throws Exception {
         try {
             String[] urls = src.split(Pattern.quote(" "));
             if(urls.length == 1) {


### PR DESCRIPTION
By delaying the startup of these services selectively, I can run both the OpenID Connect Provider AND the OpenID Connect Producer in the same membrane instance, simplifying deployment of small-scale on-premise authenticated projects. Without this pull request, Membrane will fail to start 