### PR TITLE
proxy should work with HTTP/1.0 too

### DIFF
--- a/core/src/main/java/com/predic8/membrane/core/transport/http/Connection.java
+++ b/core/src/main/java/com/predic8/membrane/core/transport/http/Connection.java
@@ -366,8 +366,8 @@ public class Connection implements MessageObserver, NonRelevantBodyObserver {
 			replyStr = new String(reply, 0, replyLen);
 		}
 
-      /* We asked for HTTP/1.0, so we should get that back */
-		if (!replyStr.startsWith("HTTP/1.1 200")) {
+        /* Look for '200 OK' response. Probably, some proxies may return HTTP/1.1 back */
+		if (!replyStr.startsWith("HTTP/1.0 200") && !replyStr.startsWith("HTTP/1.1 200")) {
 			throw new IOException("Unable to tunnel through "
 					+ proxy.getHost() + ":" + proxy.getPort()
 					+ ".  Proxy returns \"" + replyStr + "\"");


### PR DESCRIPTION
I found an obvious bug in Connection.doTunnelHandshake: it sends HTTP/1.**0** request and waits for HTTP/1.**1** response. It's very strange behavior. It doesn't work for me.
Moreover Connection.doTunnelHandshake is a clean copy of https://docs.oracle.com/javase/7/docs/technotes/guides/security/jsse/samples/sockets/client/SSLSocketClientWithTunneling.java except only this string.

I've change this line, but HTTP/1.**1** is left too because it was made for some reason, and [some people int the internet complained](https://community.oracle.com/thread/1535854) some HTTP proxies returned HTTP/1.1 response for HTTP/1.0 request