### PR TITLE
changed RedisOriginalExchangestore to expire keys

### DIFF
--- a/core/src/main/java/com/predic8/membrane/core/interceptor/oauth2client/RedisOriginalExchangeStore.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/oauth2client/RedisOriginalExchangeStore.java
@@ -64,13 +64,13 @@ public class RedisOriginalExchangeStore extends OriginalExchangeStore implements
     }
 
     private String originalRequestKeyNameInSession(String state) {
-        return prefix != null ? prefix + state : "";
+        return prefix != null ? prefix + state : state;
     }
 
     @Override
     public void store(Exchange exchange, Session session, String state, Exchange exchangeToStore) throws IOException {
         try(Jedis jedis = getJedisWithDb()){
-            jedis.set(originalRequestKeyNameInSession(state), objMapper.writeValueAsString(getTrimmedAbstractExchangeSnapshot(exchangeToStore, maxBodySize)) );
+            jedis.setex(originalRequestKeyNameInSession(state), 3600, objMapper.writeValueAsString(getTrimmedAbstractExchangeSnapshot(exchangeToStore, maxBodySize)) );
         }
     }
 

--- a/distribution/src/main/java/com/predic8/membrane/core/IDEStarter.java
+++ b/distribution/src/main/java/com/predic8/membrane/core/IDEStarter.java
@@ -23,7 +23,8 @@ import java.io.IOException;
 
 public class IDEStarter {
 	public static void main(String[] args) {
-		// TODO for testing purposes - do not commit
+		// for testing or development purposes
+		// Start in "distribution" folder
 		try {
 			File file = new File("conf/log4j2.xml");
 			Configurator.initialize(null, new ConfigurationSource(new FileInputStream(file)));


### PR DESCRIPTION
Expiring the Redis keys after 1 hour to prevent stacking originalRequests in Redis when the authorization process fails or is cancelled.