### PR TITLE
Adjust IDE Starter configuration to renamed module

### DIFF
--- a/.run/IDEStarter.run.xml
+++ b/.run/IDEStarter.run.xml
@@ -1,7 +1,7 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="IDEStarter" type="Application" factoryName="Application" nameIsGenerated="true">
     <option name="MAIN_CLASS_NAME" value="com.predic8.membrane.core.IDEStarter" />
-    <module name="membrane-service-proxy" />
+    <module name="membrane-api-gateway" />
     <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/distribution" />
     <extension name="coverage">
       <pattern>


### PR DESCRIPTION
Adjust IDE Starter configuration to match renamed module "membrane-service-proxy"