### PR TITLE
Reduce number of unchecked cast warnings when parsing JSON/YAML data

### DIFF
--- a/core/src/main/java/com/predic8/membrane/core/interceptor/apimanagement/ApiManagementConfiguration.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/apimanagement/ApiManagementConfiguration.java
@@ -13,6 +13,7 @@
 
 package com.predic8.membrane.core.interceptor.apimanagement;
 
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
 import com.predic8.membrane.core.cloud.etcd.EtcdRequest;
 import com.predic8.membrane.core.cloud.etcd.EtcdResponse;
@@ -264,8 +265,7 @@ public class ApiManagementConfiguration {
         YAMLMapper mapper = new YAMLMapper();
         Map<String,Object> yaml = null;
         try {
-
-            yaml = mapper.readValue(yamlSource, Map.class);
+            yaml = mapper.readValue(yamlSource, new TypeReference<>() {});
         } catch (IOException e) {
             log.warn("Could not parse yaml");
             return;

--- a/core/src/main/java/com/predic8/membrane/core/interceptor/jwt/Jwks.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/jwt/Jwks.java
@@ -14,6 +14,7 @@
 package com.predic8.membrane.core.interceptor.jwt;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.predic8.membrane.annot.MCAttribute;
 import com.predic8.membrane.annot.MCChildElement;
@@ -92,7 +93,7 @@ public class Jwks {
         public String getJwk(ResolverMap resolverMap, String baseLocation, ObjectMapper mapper) throws IOException {
             String maybeJwk = get(resolverMap, baseLocation);
 
-            Map<String,Object> mapped = mapper.readValue(maybeJwk,Map.class);
+            Map<String,Object> mapped = mapper.readValue(maybeJwk, new TypeReference<>() {});
 
             if(mapped.containsKey("keys"))
                 return handleJwks(mapper, mapped);

--- a/core/src/main/java/com/predic8/membrane/core/interceptor/oauth2/ConsentPageFile.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/oauth2/ConsentPageFile.java
@@ -13,6 +13,7 @@
 
 package com.predic8.membrane.core.interceptor.oauth2;
 
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.predic8.membrane.core.Router;
 import com.predic8.membrane.core.resolver.ResolverMap;
@@ -57,7 +58,7 @@ public class ConsentPageFile {
     }
 
     private void parseJson(String consentPageFile) throws IOException {
-        json = new ObjectMapper().readValue(consentPageFile, Map.class);
+        json = new ObjectMapper().readValue(consentPageFile, new TypeReference<>() {});
     }
 
     private void parseProductAndLogo() {

--- a/core/src/main/java/com/predic8/membrane/core/interceptor/oauth2/authorizationservice/MembraneAuthorizationService.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/oauth2/authorizationservice/MembraneAuthorizationService.java
@@ -13,6 +13,7 @@
 
 package com.predic8.membrane.core.interceptor.oauth2.authorizationservice;
 
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.predic8.membrane.annot.MCAttribute;
 import com.predic8.membrane.annot.MCChildElement;
@@ -144,7 +145,7 @@ public class MembraneAuthorizationService extends AuthorizationService {
     private void parseSrc(InputStream resolve) throws IOException {
         String file = IOUtils.toString(resolve);
         ObjectMapper mapper = new ObjectMapper();
-        Map<String,Object> json = mapper.readValue(file,Map.class);
+        Map<String,Object> json = mapper.readValue(file, new TypeReference<>() {});
 
         // without checks
         tokenEndpoint = (String) json.get("token_endpoint");

--- a/core/src/main/java/com/predic8/membrane/core/interceptor/oauth2/parameter/ClaimsParameter.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/oauth2/parameter/ClaimsParameter.java
@@ -15,6 +15,7 @@ package com.predic8.membrane.core.interceptor.oauth2.parameter;
 
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.predic8.membrane.core.interceptor.oauth2.ReusableJsonGenerator;
 
@@ -74,7 +75,7 @@ public class ClaimsParameter {
 
     private void parseClaimsParameter(String claimsParameter) {
         try {
-            cleanedJson = getCleanedJson(new ObjectMapper().readValue(claimsParameter,Map.class));
+            cleanedJson = getCleanedJson(new ObjectMapper().readValue(claimsParameter, new TypeReference<>() {}));
         } catch (IOException e) {
             return;
         }

--- a/core/src/test/java/com/predic8/membrane/core/interceptor/session/SessionInterceptorTest.java
+++ b/core/src/test/java/com/predic8/membrane/core/interceptor/session/SessionInterceptorTest.java
@@ -14,6 +14,7 @@
 package com.predic8.membrane.core.interceptor.session;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
 import com.predic8.membrane.core.HttpRouter;
@@ -249,12 +250,12 @@ public class SessionInterceptorTest {
     }
 
     private Map<String,Object> sendRequest() {
-        Map result;
+        Map<String, Object> result;
         HttpGet httpGet = new HttpGet("http://localhost:3001");
         try {
             try (CloseableHttpResponse response = httpClient.execute(httpGet)) {
                 String body = IOUtils.toString(response.getEntity().getContent());
-                result = new ObjectMapper().readValue(body, Map.class);
+                result = new ObjectMapper().readValue(body, new TypeReference<>() {});
                 EntityUtils.consume(response.getEntity());
             }
         } catch (Exception e) {


### PR DESCRIPTION
Pass TypeReference to ObjectMapper.readValue to preserve Map type parameters