### PR TITLE
Consistent version numbers

### DIFF
--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -17,6 +17,10 @@
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>membrane-api-gateway</artifactId>
 	<name>${project.artifactId}</name>
+	<properties>
+		<mainClass>com.predic8.membrane.core.IDEStarter</mainClass>
+		<mainArgs/>
+	</properties>
 	<packaging>jar</packaging>
 
 	<parent>
@@ -94,6 +98,12 @@
 			<version>1.5.1</version>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>com.vdurmont</groupId>
+			<artifactId>semver4j</artifactId>
+			<version>3.1.0</version>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 	<build>
@@ -164,7 +174,8 @@
 				<groupId>org.codehaus.mojo</groupId>
 				<artifactId>exec-maven-plugin</artifactId>
 				<configuration>
-					<mainClass>com.predic8.membrane.core.IDEStarter</mainClass>
+					<mainClass>${mainClass}</mainClass>
+					<commandlineArgs>${mainArgs}</commandlineArgs>
 				</configuration>
 			</plugin>
 		</plugins>

--- a/distribution/src/test/java/com/predic8/membrane/examples/env/ConsistentVersionNumbers.java
+++ b/distribution/src/test/java/com/predic8/membrane/examples/env/ConsistentVersionNumbers.java
@@ -13,6 +13,11 @@
    limitations under the License. */
 package com.predic8.membrane.examples.env;
 
+import com.vdurmont.semver4j.Semver;
+import org.apache.commons.cli.DefaultParser;
+import org.apache.commons.cli.HelpFormatter;
+import org.apache.commons.cli.Option;
+import org.apache.commons.cli.Options;
 import org.junit.jupiter.api.*;
 import org.w3c.dom.*;
 import org.xml.sax.*;
@@ -27,6 +32,7 @@ import java.util.*;
 import java.util.regex.*;
 
 import static com.predic8.membrane.examples.util.TestFileUtil.*;
+import static com.vdurmont.semver4j.Semver.SemverType.LOOSE;
 import static java.util.Objects.*;
 import static javax.xml.xpath.XPathConstants.*;
 import static org.junit.jupiter.api.Assertions.*;
@@ -45,60 +51,62 @@ public class ConsistentVersionNumbers {
 		File base = new File("..");
 		validateBase(base);
 
-		handler = (file, old) -> {
+		transformRecursively(base, (file, old) -> {
 			if (version == null)
 				version = old;
 			else {
 				try {
 					System.out.println(file);
-					assertTrue(version.equals(old) || removePatchVersion(version).equals(old));
+					assertTrue(version.isEqualTo(old) || removePatchVersion(version).isEqualTo(old));
 				} catch (RuntimeException e) {
 					throw new RuntimeException("in file " + file.getAbsolutePath(), e);
 				}
 			}
 			return old;
-		};
-		run(base);
+		});
 	}
 
-	private String removePatchVersion(String version) {
-		return version.replaceAll("^([^.]+\\.[^.]+)\\..*$", "$1");
+	private Semver removePatchVersion(Semver version) {
+		return new Semver("%d.%d".formatted(version.getMajor(), version.getMinor()), LOOSE);
 	}
 
 	@Test
 	public void testRemovePatch() {
-		assertEquals("5.0", removePatchVersion("5.0.0"));
+		assertTrue(removePatchVersion(new Semver("5.0.0")).isEqualTo("5.0"));
 	}
 
 	public static void main(String[] args) throws Exception {
 		File base = new File("..");
 		validateBase(base);
 
-		handler = (file, old) -> {
+		transformRecursively(base, (file, old) -> {
 			System.out.println(old + " " + file.getAbsolutePath());
 			return old;
-		};
-
-		run(base);
+		});
 
 		System.out.println("Please enter the new version:");
-		final String version = new BufferedReader(new InputStreamReader(System.in)).readLine();
+		final Semver version = new Semver(new BufferedReader(new InputStreamReader(System.in)).readLine(), LOOSE);
 
-		handler = (file, old) -> version;
-
-		run(base);
+		transformRecursively(base, (file, old) -> version);
 	}
 
-	private static void run(File base) throws Exception {
-		recurse(base, 2);
-
-		handlePOM(new File(base.getAbsolutePath() + "/distribution/examples/embedding-java/pom.xml"), false);
-		handlePOM(new File(base.getAbsolutePath() + "/distribution/examples/stax-interceptor/pom.xml"), false);
-
-		handleHelpReference(new File(base.getAbsolutePath() + "/annot/src/main/java/com/predic8/membrane/annot/generator/HelpReference.java"));
+	private static Options getOptions() {
+		var options = new Options();
+		options.addOption(SNAPSHOT);
+		options.addOption(RELEASE);
+		return options;
 	}
 
-	private static void handleHelpReference(File file) throws Exception {
+	private static void transformRecursively(File baseDirectory, VersionTransformer versionTransformer) throws Exception {
+		recurse(baseDirectory, versionTransformer, 2);
+
+		handlePOM(new File(baseDirectory.getAbsolutePath(), "/distribution/examples/embedding-java/pom.xml"), false, versionTransformer);
+		handlePOM(new File(baseDirectory.getAbsolutePath(), "/distribution/examples/stax-interceptor/pom.xml"), false, versionTransformer);
+
+		handleHelpReference(new File(baseDirectory.getAbsolutePath(), "/annot/src/main/java/com/predic8/membrane/annot/generator/HelpReference.java"), versionTransformer);
+	}
+
+	private static void handleHelpReference(File file, VersionTransformer versionTransformer) throws Exception {
 		// path.replace("%VERSION%", "5.0")
 		List<String> content = getFileContentAsLines(file);
 		boolean found = false;
@@ -107,10 +115,8 @@ public class ConsistentVersionNumbers {
 			Matcher m = pattern.matcher(content.get(i));
 			if (m.find()) {
 				found = true;
-				String v = handler.handle(file, m.group(2));
-				// only put "$major.$minor" into HelpReference.java
-				v = v.replaceAll("([^.]+\\.[^.]+)\\..*", "$1");
-				content.set(i, m.replaceFirst(m.group(1) + v + m.group(3)));
+				Semver v = versionTransformer.map(file, new Semver(m.group(2), LOOSE));
+				content.set(i, m.replaceFirst(m.group(1) + "%d.%d".formatted(v.getMajor(), v.getMinor()) + m.group(3)));
 			}
 		}
 		if (!found)
@@ -129,30 +135,30 @@ public class ConsistentVersionNumbers {
 			throw new Exception("Could not find Membrane's main core/pom.xml.");
 	}
 
-	private static void recurse(File base, int i) throws Exception {
+	private static void recurse(File directory, VersionTransformer versionTransformer, int i) throws Exception {
 		if (i == 0)
 			return;
-		for (File child : requireNonNull(base.listFiles())) {
+		for (File child : requireNonNull(directory.listFiles())) {
 			if (child.isFile() && child.getName().equals("pom.xml"))
-				handlePOM(child, true);
+				handlePOM(child, true, versionTransformer);
 			if (child.isFile() && child.getName().equals(".factorypath"))
-				handleFactoryPath(child);
+				handleFactoryPath(child, versionTransformer);
 			if (child.isDirectory())
-				recurse(child, i-1);
+				recurse(child, versionTransformer, i-1);
 		}
 	}
 
-	private static void handlePOM(File child, boolean isPartOfProject) throws XPathExpressionException, SAXException, IOException, ParserConfigurationException, TransformerException, TransformerFactoryConfigurationError {
-		//System.out.println(child.getName());
+	private static void handlePOM(File pomFilename, boolean isPartOfProject, VersionTransformer versionTransformer) throws XPathExpressionException, SAXException, IOException, ParserConfigurationException, TransformerException, TransformerFactoryConfigurationError {
+		//System.out.println(pomFilename.getName());
 		DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
 		//dbf.setNamespaceAware(true);
-		Document d = dbf.newDocumentBuilder().parse(child);
+		Document d = dbf.newDocumentBuilder().parse(pomFilename);
 		NodeList l = (NodeList) getNodeSelector(isPartOfProject).evaluate(d, NODESET);
 		for (int i = 0; i < l.getLength(); i++) {
 			Element e = (Element) l.item(i);
-			e.getFirstChild().setNodeValue(handler.handle(child, e.getFirstChild().getNodeValue()));
+			e.getFirstChild().setNodeValue(versionTransformer.map(pomFilename, new Semver(e.getFirstChild().getNodeValue(), LOOSE)).getValue());
 		}
-		TransformerFactory.newInstance().newTransformer().transform(new DOMSource(d), new StreamResult(child));
+		TransformerFactory.newInstance().newTransformer().transform(new DOMSource(d), new StreamResult(pomFilename));
 	}
 
 	private static XPathExpression getNodeSelector(boolean isPartOfProject) throws XPathExpressionException {
@@ -166,10 +172,10 @@ public class ConsistentVersionNumbers {
 
 	}
 
-	private static void handleFactoryPath(File child) throws XPathExpressionException, SAXException, IOException, ParserConfigurationException, TransformerException, TransformerFactoryConfigurationError {
+	private static void handleFactoryPath(File factoryPath, VersionTransformer versionTransformer) throws XPathExpressionException, SAXException, IOException, ParserConfigurationException, TransformerException, TransformerFactoryConfigurationError {
 		DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
 		//dbf.setNamespaceAware(true);
-		Document d = dbf.newDocumentBuilder().parse(child);
+		Document d = dbf.newDocumentBuilder().parse(factoryPath);
 		XPathFactory pf = XPathFactory.newInstance();
 		XPath p = pf.newXPath();
 		NodeList l = (NodeList) p.compile("//factorypath/factorypathentry[@kind='VARJAR' and contains(@id, 'service-proxy-annot')]").evaluate(d, NODESET);
@@ -179,13 +185,13 @@ public class ConsistentVersionNumbers {
 			Matcher m = Pattern.compile("service-proxy-annot-(.*?).jar").matcher(e.getAttribute("id"));
 			if (!m.find())
 				throw new RuntimeException("Could not match: " + e.getAttribute("id"));
-			String newValue = handler.handle(child, m.group(1));
+			String newValue = versionTransformer.map(factoryPath, new Semver(m.group(1), LOOSE)).getValue();
 			e.setAttribute("id", "M2_REPO/org/membrane-soa/service-proxy-annot/" + newValue + "/service-proxy-annot-" + newValue + ".jar");
 		}
-		TransformerFactory.newInstance().newTransformer().transform(new DOMSource(d), new StreamResult(child));
+		TransformerFactory.newInstance().newTransformer().transform(new DOMSource(d), new StreamResult(factoryPath));
 	}
 
-	private interface Handler {
-		String handle(File file, String old);
+	private interface VersionTransformer {
+		Semver map(File file, Semver old);
 	}
 }

--- a/distribution/src/test/java/com/predic8/membrane/examples/env/ConsistentVersionNumbers.java
+++ b/distribution/src/test/java/com/predic8/membrane/examples/env/ConsistentVersionNumbers.java
@@ -41,6 +41,12 @@ import static org.junit.jupiter.api.Assertions.*;
 /**
  * This test checks that all version numbers in the miscellaneous project files
  * are the same.
+ *
+ * Call from distribution directory.
+ * For Release, use:
+ * {@code mvn test-compile exec:java -DmainClass="com.predic8.membrane.examples.env.ConsistentVersionNumbers" -Dexec.classpathScope="test" -DmainArgs="-release 5.2"}
+ * For Snapshot version, use:
+ * {@code mvn test-compile exec:java -DmainClass="com.predic8.membrane.examples.env.ConsistentVersionNumbers" -Dexec.classpathScope="test" -DmainArgs="-snapshot"}
  */
 public class ConsistentVersionNumbers {
 

--- a/distribution/src/test/java/com/predic8/membrane/examples/env/ConsistentVersionNumbers.java
+++ b/distribution/src/test/java/com/predic8/membrane/examples/env/ConsistentVersionNumbers.java
@@ -147,18 +147,23 @@ public class ConsistentVersionNumbers {
 		DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
 		//dbf.setNamespaceAware(true);
 		Document d = dbf.newDocumentBuilder().parse(child);
-		XPathFactory pf = XPathFactory.newInstance();
-		XPath p = pf.newXPath();
-		NodeList l = (NodeList) p.compile(
-				isPartOfProject ?
-						"//project/version | //project/parent/version" :
-							"//project/dependencies/dependency[./artifactId='service-proxy-core']/version"
-				).evaluate(d, NODESET);
+		NodeList l = (NodeList) getNodeSelector(isPartOfProject).evaluate(d, NODESET);
 		for (int i = 0; i < l.getLength(); i++) {
 			Element e = (Element) l.item(i);
 			e.getFirstChild().setNodeValue(handler.handle(child, e.getFirstChild().getNodeValue()));
 		}
 		TransformerFactory.newInstance().newTransformer().transform(new DOMSource(d), new StreamResult(child));
+	}
+
+	private static XPathExpression getNodeSelector(boolean isPartOfProject) throws XPathExpressionException {
+		XPathFactory pf = XPathFactory.newInstance();
+		XPath p = pf.newXPath();
+		return p.compile(
+				isPartOfProject ?
+						"//project/version | //project/parent/version" :
+						"//project/dependencies/dependency[./artifactId='service-proxy-core']/version"
+		);
+
 	}
 
 	private static void handleFactoryPath(File child) throws XPathExpressionException, SAXException, IOException, ParserConfigurationException, TransformerException, TransformerFactoryConfigurationError {


### PR DESCRIPTION
Add Command line options to ConsistentVersionNumbers:
* `-snapshot` increases patch version and appends "-SNAPSHOT" suffix if not already present
* `-release 5.2' creates a release version