### PR TITLE
Added fileUserDataProvider & integration into basic-auth example

### DIFF
--- a/core/src/main/java/com/predic8/membrane/core/interceptor/authentication/session/FileUserDataProvider.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/authentication/session/FileUserDataProvider.java
@@ -33,10 +33,10 @@ public class FileUserDataProvider implements UserDataProvider {
         String postDataPassword = postData.get("password");
         String userHash = userAttributes.getPassword();
         String[] userHashSplit = userHash.split("\\$");
-        String salt = userHashSplit[1];
-        String algo = userHashSplit[0];
+        String salt = userHashSplit[2];
+        String algo = userHashSplit[1];
         try {
-            pw = createPasswdCompatibleHash(algo, postDataPassword, salt);
+            pw = createHtpasswdKeyString(algo, postDataPassword, salt);
         } catch (UnsupportedEncodingException | NoSuchAlgorithmException e) {
             throw new RuntimeException(e.getMessage());
         }
@@ -47,7 +47,7 @@ public class FileUserDataProvider implements UserDataProvider {
         return userAttributes.getAttributes();
     }
 
-    private String createPasswdCompatibleHash(String algo, String password, String salt) throws UnsupportedEncodingException, NoSuchAlgorithmException {
+    private String createHtpasswdKeyString(String algo, String password, String salt) throws UnsupportedEncodingException, NoSuchAlgorithmException {
         return Crypt.crypt(password, "$" + algo + "$" + salt);
     }
 

--- a/core/src/main/java/com/predic8/membrane/core/interceptor/authentication/session/FileUserDataProvider.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/authentication/session/FileUserDataProvider.java
@@ -23,9 +23,9 @@ import java.security.NoSuchAlgorithmException;
 import java.util.*;
 
 /**
- * @description A <i>user data provider</i> utilizing htaccess formatted files.
+ * @description A <i>user data provider</i> utilizing htpasswd formatted files.
  * @explanation <p>
- *              the <i>fileuserdataprovider</i> can be used to source authentication data from htaccess files.
+ *              the <i>fileuserdataprovider</i> can be used to source authentication data from htpasswd files.
  *              </p>
  *              <p>
  *              The files can only utilize algorithm magic strings supported by <i>crypt(3)</i>.
@@ -38,7 +38,7 @@ public class FileUserDataProvider implements UserDataProvider {
     private String htpasswdPath;
 
     /**
-     * @description A path pointing to the htaccess file.
+     * @description A path pointing to the htpasswd file.
      */
     @MCAttribute
     public void setHtpasswdPath(String path) {

--- a/core/src/main/java/com/predic8/membrane/core/interceptor/authentication/session/FileUserDataProvider.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/authentication/session/FileUserDataProvider.java
@@ -1,3 +1,16 @@
+/* Copyright 2023 predic8 GmbH, www.predic8.com
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
 package com.predic8.membrane.core.interceptor.authentication.session;
 
 import com.predic8.membrane.annot.MCAttribute;

--- a/core/src/main/java/com/predic8/membrane/core/interceptor/authentication/session/FileUserDataProvider.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/authentication/session/FileUserDataProvider.java
@@ -1,0 +1,107 @@
+package com.predic8.membrane.core.interceptor.authentication.session;
+
+import com.predic8.membrane.annot.MCAttribute;
+import com.predic8.membrane.annot.MCElement;
+import com.predic8.membrane.core.Router;
+import org.apache.commons.codec.digest.Crypt;
+import java.io.*;
+import java.nio.file.*;
+import java.security.NoSuchAlgorithmException;
+import java.util.*;
+
+@MCElement(name="fileUserDataProvider")
+public class FileUserDataProvider implements UserDataProvider {
+    private final Map<String, User> usersByName = new HashMap<>();
+
+    private String htpasswdPath;
+
+    @MCAttribute
+    public void setHtpasswdPath(String path) {
+        this.htpasswdPath = path;
+    }
+
+    @Override
+    public Map<String, String> verify(Map<String, String> postData) {
+        String username = postData.get("username");
+        if (username == null)
+            throw new NoSuchElementException();
+        User userAttributes;
+        userAttributes = getUsersByName().get(username);
+        if (userAttributes == null)
+            throw new NoSuchElementException();
+        String pw = null;
+        String postDataPassword = postData.get("password");
+        String userHash = userAttributes.getPassword();
+        String[] userHashSplit = userHash.split("\\$");
+        String salt = userHashSplit[1];
+        String algo = userHashSplit[0];
+        try {
+            pw = createPasswdCompatibleHash(algo, postDataPassword, salt);
+        } catch (UnsupportedEncodingException | NoSuchAlgorithmException e) {
+            throw new RuntimeException(e.getMessage());
+        }
+        String pw2;
+        pw2 = userAttributes.getPassword();
+        if (pw2 == null || !pw2.equals(pw))
+            throw new NoSuchElementException();
+        return userAttributes.getAttributes();
+    }
+
+    private String createPasswdCompatibleHash(String algo, String password, String salt) throws UnsupportedEncodingException, NoSuchAlgorithmException {
+        return Crypt.crypt(password, "$" + algo + "$" + salt);
+    }
+
+    public static class User {
+        Map<String, String> attributes = new HashMap<>();
+
+        public User(String username, String password){
+            setUsername(username);
+            setPassword(password);
+        }
+
+        public String getUsername() {
+            return attributes.get("username");
+        }
+
+        public void setUsername(String value) {
+            attributes.put("username", value);
+        }
+
+        public String getPassword() {
+            return attributes.get("password");
+        }
+
+        public void setPassword(String value) {
+            attributes.put("password", value);
+        }
+
+        public Map<String, String> getAttributes() {
+            return attributes;
+        }
+
+        public void setAttributes(Map<String, String> attributes) {
+            this.attributes.putAll(attributes);
+        }
+    }
+
+    public Map<String, User> getUsersByName() {
+        return usersByName;
+    }
+
+    @Override
+    public void init(Router router) {
+        List<String> lines = null;
+        try {
+            lines = Files.readAllLines(Paths.get(this.htpasswdPath));
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+        for (String line : lines) {
+            String[] parts = line.split(":");
+            if (parts.length == 2) {
+                User user = new User(parts[0], parts[1]);
+                getUsersByName().put(user.getUsername(), user);
+            }
+        }
+    }
+}

--- a/core/src/main/java/com/predic8/membrane/core/interceptor/authentication/session/FileUserDataProvider.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/authentication/session/FileUserDataProvider.java
@@ -22,12 +22,24 @@ import java.nio.file.*;
 import java.security.NoSuchAlgorithmException;
 import java.util.*;
 
+/**
+ * @description A <i>user data provider</i> utilizing htaccess formatted files.
+ * @explanation <p>
+ *              the <i>fileuserdataprovider</i> can be used to source authentication data from htaccess files.
+ *              </p>
+ *              <p>
+ *              The files can only utilize algorithm magic strings supported by <i>crypt(3)</i>.
+ *              </p>
+ */
 @MCElement(name="fileUserDataProvider")
 public class FileUserDataProvider implements UserDataProvider {
     private final Map<String, User> usersByName = new HashMap<>();
 
     private String htpasswdPath;
 
+    /**
+     * @description A path pointing to the htaccess file.
+     */
     @MCAttribute
     public void setHtpasswdPath(String path) {
         this.htpasswdPath = path;

--- a/distribution/examples/basic-auth/.htpasswd
+++ b/distribution/examples/basic-auth/.htpasswd
@@ -1,0 +1,2 @@
+membrane:$5$9d3c06e19528aebb$cZBA3E3SdoUvk865.WyPA5iNUEA7uwDlDX7D5Npkh8/
+john:$5$99a6391616158b48$PqFPn9f/ojYdRcu.TVsdKeeRHKwbWApdEypn6wlUQn5

--- a/distribution/examples/basic-auth/README.md
+++ b/distribution/examples/basic-auth/README.md
@@ -35,6 +35,7 @@ First take a look at the `proxies.xml` file.
 	<basicAuthentication>
 	  <fileUserDataProvider htpasswdPath="./.htpasswd" />
 	</basicAuthentication>
+	<target url="https://api.predic8.de"/>
   </api>
 </router>
 ```

--- a/distribution/examples/basic-auth/README.md
+++ b/distribution/examples/basic-auth/README.md
@@ -51,7 +51,7 @@ Now take a closer look at the `<basicAuthentication>` element:
 ```
 
 Users are added through `user` elements. The username and the password are given by the attributes `name` and `password` of the `user` element. The example demonstrates one user, with username `alice` and password `membrane`.   
-Alternatively, the `fileUserDataProvider` can be used to read basic authentication data from an htaccess formatted file. The algorithm magic strings must be compatible with Unix `crypt(3)`.
+Alternatively, the `fileUserDataProvider` can be used to read basic authentication data from an htpasswd formatted file. The algorithm magic strings must be compatible with Unix `crypt(3)`.
 
 When opening the URL `http://localhost:2000/` or the `3000` port equivalent, membrane will respond with `401 Not Authorized`.
 

--- a/distribution/examples/basic-auth/README.md
+++ b/distribution/examples/basic-auth/README.md
@@ -14,6 +14,10 @@ This example explains how to protect an API or a Web application using __HTTP Ba
 
 4. Login with the username `alice` and the password `membrane`.
 
+5. Open the URL http://localhost:3000 in your browser.
+
+6. Login with credentials `membrane` & `proxy` or `john` & `smith123`
+
 
 ## How it is done
 
@@ -27,10 +31,15 @@ First take a look at the `proxies.xml` file.
     </basicAuthentication>
     <target url="https://api.predic8.de"/>
   </api>
+  <api port="3000">
+	<basicAuthentication>
+	  <fileUserDataProvider htpasswdPath="./.htpasswd" />
+	</basicAuthentication>
+  </api>
 </router>
 ```
 
-There is an `<api>` that directs calls from the port 2000 to `https://api.predic8.de`. The basicAuthentication-plugin is called for every request.
+There are two `<api>` components that direct calls from port `2000` and `3000` to `https://api.predic8.de`. The basicAuthentication-plugin is called for every request.
 
 Now take a closer look at the `<basicAuthentication>` element:
 
@@ -40,9 +49,10 @@ Now take a closer look at the `<basicAuthentication>` element:
 </basicAuthentication>
 ```
 
-You can add users by using `user` elements. The `username` and the `password` are given by the attributes name and password of the `user` element. In the example there is one user with username `alice` and password `membrane`. 
+Users are added through `user` elements. The username and the password are given by the attributes `name` and `password` of the `user` element. The example demonstrates one user, with username `alice` and password `membrane`.   
+Alternatively, the `fileUserDataProvider` can be used to read basic authentication data from an htaccess formatted file. The algorithm magic strings must be compatible with Unix `crypt(3)`.
 
-When opening the URL `http://localhost:2000/` membrane will respond with `401 Not Authorized`.
+When opening the URL `http://localhost:2000/` or the `3000` port equivalent, membrane will respond with `401 Not Authorized`.
 
 ```
 HTTP/1.1 401 Unauthorized

--- a/distribution/examples/basic-auth/proxies.xml
+++ b/distribution/examples/basic-auth/proxies.xml
@@ -17,6 +17,7 @@
 			<basicAuthentication>
 				<fileUserDataProvider htpasswdPath="./.htpasswd" />
 			</basicAuthentication>
+			<target url="https://api.predic8.de"/>
 		</api>
 	
 	</router>

--- a/distribution/examples/basic-auth/proxies.xml
+++ b/distribution/examples/basic-auth/proxies.xml
@@ -12,6 +12,12 @@
 			</basicAuthentication>
 			<target url="https://api.predic8.de"/>
 		</api>
+
+		<api port="3000">
+			<basicAuthentication>
+				<fileUserDataProvider htpasswdPath="./.htpasswd" />
+			</basicAuthentication>
+		</api>
 	
 	</router>
 	


### PR DESCRIPTION
Added a UserDataProvider compatible with htpasswd formatted files.
Added the the provider to the basic-auth example next to the StaticUserDataProvider example.