### PR TITLE
escaped @Mozilla for doc generation

### DIFF
--- a/core/src/main/java/com/predic8/membrane/core/interceptor/ratelimit/RateLimitInterceptor.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/ratelimit/RateLimitInterceptor.java
@@ -47,7 +47,7 @@ import static java.lang.String.*;
  * The X-Forwarded-For header can only be trusted when a trustworthy reverse proxy or load balancer is between the client and server. The gateway not should be
  * reachable directly. Only activate this feature when you know what you are doing.
  * </p>
- * @see <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-For">X-Forwarded-For @Mozilla</a>
+ * @see <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-For">X-Forwarded-For &#64;Mozilla</a>
  */
 @MCElement(name = "rateLimiter")
 public class RateLimitInterceptor extends AbstractInterceptor {


### PR DESCRIPTION
escaped `@Mozilla` the `@see` notation is valid and used in other classes like `SSLCapabilities.java`