### PR TITLE
wip enabled basic logging and configuring in apache commons log forma…

### DIFF
--- a/core/src/main/java/com/predic8/membrane/core/interceptor/log/AccessLogInterceptor.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/log/AccessLogInterceptor.java
@@ -1,0 +1,155 @@
+package com.predic8.membrane.core.interceptor.log;
+
+import com.predic8.membrane.annot.MCAttribute;
+import com.predic8.membrane.annot.MCChildElement;
+import com.predic8.membrane.annot.MCElement;
+import com.predic8.membrane.core.exchange.Exchange;
+import com.predic8.membrane.core.interceptor.AbstractInterceptor;
+import com.predic8.membrane.core.interceptor.Outcome;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
+import org.springframework.expression.spel.standard.SpelExpressionParser;
+
+import java.text.SimpleDateFormat;
+import java.util.AbstractMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+/**
+ * @description Writes exchange metrics into a Log4j appender
+ * @explanation Defaults to Apache Common Log pattern
+ */
+@MCElement(name = "accessLog")
+public class AccessLogInterceptor extends AbstractInterceptor {
+
+    private static final Logger log = LoggerFactory.getLogger(AccessLogInterceptor.class);
+
+    private List<AdditionalPattern> additionalPatternList;
+    private String defaultValue = "-";
+    private String dateTimePattern = "dd/MM/yyyy:HH:mm:ss Z";
+    private SimpleDateFormat dateTimeFormat = new SimpleDateFormat(dateTimePattern);
+
+    @Override
+    public Outcome handleResponse(Exchange exc) throws Exception {
+        handleAccessLogging(exc);
+        return super.handleResponse(exc);
+    }
+
+    /**
+     * Handles access logging with custom MDC parameters
+     * MDC often uses ThreadLocals to archive thread safety.
+     * Using thread pools and reusing borrowed threads could lead to leftover MDC data
+     * to be thread pool safe, we simply clear the MDC after usage
+     *
+     * @param exchange - The HTTP exchange
+     */
+    private void handleAccessLogging(Exchange exchange) {
+        fillMDCMap(exchange);
+        log.info("");
+        MDC.clear();
+    }
+
+    private Map<String, String> getAdditionalProvidedPattern(Exchange exchange, Map<String, String> existingPatternMap) {
+        if (additionalPatternList.isEmpty()) return Map.of();
+
+        return additionalPatternList.stream().map(additionalPattern -> {
+            if (!additionalPattern.isOverride() && existingPatternMap.containsKey(additionalPattern.getCreate())) {
+                return null;
+            }
+
+            var value = new SpelExpressionParser()
+                    .parseExpression(additionalPattern.getWithExchange()).getValue(exchange);
+
+            return new AbstractMap.SimpleEntry<>(additionalPattern.getCreate(), value != null ? value.toString() : additionalPattern.getOrDefaultValue());
+        })
+        .filter(Objects::nonNull)
+        .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+    }
+
+    private void fillMDCMap(Exchange exchange) {
+        var contextMap = normalize(getDefinitelySetProperties(exchange));
+        var responseMap = normalize(getMaybeSetResposeProperties(exchange));
+
+        // possible override of key in order of importance
+        contextMap.putAll(responseMap);
+        contextMap.putAll(getAdditionalProvidedPattern(exchange, contextMap));
+
+        MDC.setContextMap(contextMap);
+    }
+
+    private Map<String, String> normalize(Map<String, Object> input) {
+        return input.entrySet().stream()
+                .collect(Collectors.toMap(Map.Entry::getKey, entry ->
+                        entry.getValue() != null ? entry.getValue().toString() : defaultValue));
+    }
+
+    private Map<String, Object> getDefinitelySetProperties(Exchange exchange) {
+        return Map.of(
+                "ip", exchange.getRemoteAddrIp(),
+                "time", convert(exchange.getTimeReqReceived()),
+                "host", exchange.getOriginalHostHeaderHost(),
+                "port", exchange.getOriginalHostHeaderPort(),
+                "uri", exchange.getRequestURI(),
+                "proto", exchange.getRequest().getHeader().getFirstValue("x-forwarded-proto").toUpperCase(),
+                "http.version", exchange.getRequest().getVersion(),
+                "http.method", exchange.getRequest().getMethod(),
+                "statusCode", defaultValue
+        );
+    }
+
+    private String convert(long timestamp) {
+        return dateTimeFormat.format(timestamp);
+    }
+
+    private Map<String, Object> getMaybeSetResposeProperties(Exchange exchange) {
+        if (exchange.getResponse() == null) return Map.of();
+
+        return Map.of(
+                "statusCode", exchange.getResponse().getStatusCode(),
+                // TODO this will disable "streaming" as noticed in the method
+                // "payload.size", exchange.getResponse().getBody().getLength()
+                "payload.size", exchange.getResponse().getHeader().getFirstValue("content-length")
+        );
+    }
+
+    public List<AdditionalPattern> getAdditionalPatternList() {
+        return additionalPatternList;
+    }
+
+    @MCChildElement
+    public void setAdditionalPatternList(List<AdditionalPattern> additionalPatternList) {
+        this.additionalPatternList = additionalPatternList;
+    }
+
+    public String getDefaultValue() {
+        return defaultValue;
+    }
+
+    /**
+     * @description - Provide a default value if the exchange property could not be found, defaults to "-"
+     */
+    @MCAttribute
+    public void setDefaultValue(String defaultValue) {
+        this.defaultValue = defaultValue;
+    }
+
+    public String getDateTimePattern() {
+        return dateTimePattern;
+    }
+
+    /**
+     * @description - Provide a datetime pattern, defaults to "dd/MM/yyyy:HH:mm:ss Z"
+     */
+    @MCAttribute
+    public void setDateTimePattern(String dateTimePattern) {
+        this.dateTimePattern = dateTimePattern;
+        this.dateTimeFormat = new SimpleDateFormat(dateTimePattern);
+    }
+
+    Logger getLog() {
+        return log;
+    }
+}

--- a/core/src/main/java/com/predic8/membrane/core/interceptor/log/AccessLogInterceptor.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/log/AccessLogInterceptor.java
@@ -148,8 +148,4 @@ public class AccessLogInterceptor extends AbstractInterceptor {
         this.dateTimePattern = dateTimePattern;
         this.dateTimeFormat = new SimpleDateFormat(dateTimePattern);
     }
-
-    Logger getLog() {
-        return log;
-    }
 }

--- a/core/src/main/java/com/predic8/membrane/core/interceptor/log/AccessLogInterceptor.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/log/AccessLogInterceptor.java
@@ -92,7 +92,7 @@ public class AccessLogInterceptor extends AbstractInterceptor {
                 "time", convert(exchange.getTimeReqReceived()),
                 "host", exchange.getOriginalHostHeaderHost(),
                 "port", exchange.getOriginalHostHeaderPort(),
-                "uri", exchange.getRequestURI(),
+                "uri", exchange.getOriginalRequestUri(),
                 "proto", exchange.getRequest().getHeader().getFirstValue("x-forwarded-proto").toUpperCase(),
                 "http.version", exchange.getRequest().getVersion(),
                 "http.method", exchange.getRequest().getMethod(),
@@ -108,10 +108,9 @@ public class AccessLogInterceptor extends AbstractInterceptor {
         if (exchange.getResponse() == null) return Map.of();
 
         return Map.of(
-                "statusCode", exchange.getResponse().getStatusCode(),
+                "statusCode", exchange.getResponse().getStatusCode()
                 // TODO this will disable "streaming" as noticed in the method
                 // "payload.size", exchange.getResponse().getBody().getLength()
-                "payload.size", exchange.getResponse().getHeader().getFirstValue("content-length")
         );
     }
 

--- a/core/src/main/java/com/predic8/membrane/core/interceptor/log/AccessLogInterceptor.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/log/AccessLogInterceptor.java
@@ -6,17 +6,8 @@ import com.predic8.membrane.annot.MCElement;
 import com.predic8.membrane.core.exchange.Exchange;
 import com.predic8.membrane.core.interceptor.AbstractInterceptor;
 import com.predic8.membrane.core.interceptor.Outcome;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.slf4j.MDC;
-import org.springframework.expression.spel.standard.SpelExpressionParser;
 
-import java.text.SimpleDateFormat;
-import java.util.AbstractMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.stream.Collectors;
+import java.util.*;
 
 /**
  * @description Writes exchange metrics into a Log4j appender
@@ -24,94 +15,29 @@ import java.util.stream.Collectors;
  */
 @MCElement(name = "accessLog")
 public class AccessLogInterceptor extends AbstractInterceptor {
-
-    private static final Logger log = LoggerFactory.getLogger(AccessLogInterceptor.class);
-
-    private List<AdditionalPattern> additionalPatternList;
+    private List<AdditionalPattern> additionalPatternList = new ArrayList<>();
     private String defaultValue = "-";
     private String dateTimePattern = "dd/MM/yyyy:HH:mm:ss Z";
-    private SimpleDateFormat dateTimeFormat = new SimpleDateFormat(dateTimePattern);
+    private boolean excludePayloadSize = false;
+
+    private AccessLogInterceptorService accessLogInterceptorService;
+
+    @Override
+    public void init() throws Exception {
+        super.init();
+
+        accessLogInterceptorService = new AccessLogInterceptorService(
+                dateTimePattern,
+                defaultValue,
+                additionalPatternList,
+                excludePayloadSize
+        );
+    }
 
     @Override
     public Outcome handleResponse(Exchange exc) throws Exception {
-        handleAccessLogging(exc);
+        accessLogInterceptorService.handleAccessLogging(exc);
         return super.handleResponse(exc);
-    }
-
-    /**
-     * Handles access logging with custom MDC parameters
-     * MDC often uses ThreadLocals to archive thread safety.
-     * Using thread pools and reusing borrowed threads could lead to leftover MDC data
-     * to be thread pool safe, we simply clear the MDC after usage
-     *
-     * @param exchange - The HTTP exchange
-     */
-    private void handleAccessLogging(Exchange exchange) {
-        fillMDCMap(exchange);
-        log.info("");
-        MDC.clear();
-    }
-
-    private Map<String, String> getAdditionalProvidedPattern(Exchange exchange, Map<String, String> existingPatternMap) {
-        if (additionalPatternList.isEmpty()) return Map.of();
-
-        return additionalPatternList.stream().map(additionalPattern -> {
-            if (!additionalPattern.isOverride() && existingPatternMap.containsKey(additionalPattern.getCreate())) {
-                return null;
-            }
-
-            var value = new SpelExpressionParser()
-                    .parseExpression(additionalPattern.getWithExchange()).getValue(exchange);
-
-            return new AbstractMap.SimpleEntry<>(additionalPattern.getCreate(), value != null ? value.toString() : additionalPattern.getOrDefaultValue());
-        })
-        .filter(Objects::nonNull)
-        .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
-    }
-
-    private void fillMDCMap(Exchange exchange) {
-        var contextMap = normalize(getDefinitelySetProperties(exchange));
-        var responseMap = normalize(getMaybeSetResposeProperties(exchange));
-
-        // possible override of key in order of importance
-        contextMap.putAll(responseMap);
-        contextMap.putAll(getAdditionalProvidedPattern(exchange, contextMap));
-
-        MDC.setContextMap(contextMap);
-    }
-
-    private Map<String, String> normalize(Map<String, Object> input) {
-        return input.entrySet().stream()
-                .collect(Collectors.toMap(Map.Entry::getKey, entry ->
-                        entry.getValue() != null ? entry.getValue().toString() : defaultValue));
-    }
-
-    private Map<String, Object> getDefinitelySetProperties(Exchange exchange) {
-        return Map.of(
-                "ip", exchange.getRemoteAddrIp(),
-                "time", convert(exchange.getTimeReqReceived()),
-                "host", exchange.getOriginalHostHeaderHost(),
-                "port", exchange.getOriginalHostHeaderPort(),
-                "uri", exchange.getOriginalRequestUri(),
-                "proto", exchange.getRequest().getHeader().getFirstValue("x-forwarded-proto").toUpperCase(),
-                "http.version", exchange.getRequest().getVersion(),
-                "http.method", exchange.getRequest().getMethod(),
-                "statusCode", defaultValue
-        );
-    }
-
-    private String convert(long timestamp) {
-        return dateTimeFormat.format(timestamp);
-    }
-
-    private Map<String, Object> getMaybeSetResposeProperties(Exchange exchange) {
-        if (exchange.getResponse() == null) return Map.of();
-
-        return Map.of(
-                "statusCode", exchange.getResponse().getStatusCode()
-                // TODO this will disable "streaming" as noticed in the method
-                // "payload.size", exchange.getResponse().getBody().getLength()
-        );
     }
 
     public List<AdditionalPattern> getAdditionalPatternList() {
@@ -145,6 +71,17 @@ public class AccessLogInterceptor extends AbstractInterceptor {
     @MCAttribute
     public void setDateTimePattern(String dateTimePattern) {
         this.dateTimePattern = dateTimePattern;
-        this.dateTimeFormat = new SimpleDateFormat(dateTimePattern);
+    }
+
+    public boolean isExcludePayloadSize() {
+        return excludePayloadSize;
+    }
+
+    /**
+     * @description - Reading the payload size would disable "Streaming", defaults to false
+     */
+    @MCAttribute
+    public void setExcludePayloadSize(boolean excludePayloadSize) {
+        this.excludePayloadSize = excludePayloadSize;
     }
 }

--- a/core/src/main/java/com/predic8/membrane/core/interceptor/log/AccessLogInterceptor.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/log/AccessLogInterceptor.java
@@ -9,6 +9,8 @@ import com.predic8.membrane.core.interceptor.Outcome;
 
 import java.util.*;
 
+import static com.predic8.membrane.core.interceptor.Outcome.CONTINUE;
+
 /**
  * @description Writes exchange metrics into a Log4j appender
  * @explanation Defaults to Apache Common Log pattern
@@ -37,7 +39,7 @@ public class AccessLogInterceptor extends AbstractInterceptor {
     @Override
     public Outcome handleResponse(Exchange exc) throws Exception {
         accessLogInterceptorService.handleAccessLogging(exc);
-        return super.handleResponse(exc);
+        return CONTINUE;
     }
 
     public List<AdditionalPattern> getAdditionalPatternList() {

--- a/core/src/main/java/com/predic8/membrane/core/interceptor/log/AccessLogInterceptorService.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/log/AccessLogInterceptorService.java
@@ -1,0 +1,155 @@
+package com.predic8.membrane.core.interceptor.log;
+
+import com.predic8.membrane.core.exchange.Exchange;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
+import org.springframework.expression.spel.standard.SpelExpressionParser;
+
+import java.io.IOException;
+import java.text.SimpleDateFormat;
+import java.util.AbstractMap;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+public class AccessLogInterceptorService {
+
+    private static final Logger log = LoggerFactory.getLogger(AccessLogInterceptor.class);
+
+    private final SimpleDateFormat dateTimeFormat;
+    private final String defaultValue;
+    private final List<AdditionalPattern> additionalPatternList;
+    private final boolean excludePayloadSize;
+
+    public AccessLogInterceptorService(
+            String dateTimePattern,
+            String defaultValue,
+            List<AdditionalPattern> additionalPatternList,
+            boolean excludePayloadSize
+    ) {
+        this.dateTimeFormat = new SimpleDateFormat(dateTimePattern);
+        this.defaultValue = defaultValue;
+        this.additionalPatternList = additionalPatternList;
+        this.excludePayloadSize = excludePayloadSize;
+    }
+
+    /**
+     * Handles access logging with custom MDC parameters
+     * MDC often uses ThreadLocals to archive thread safety.
+     * Using thread pools and reusing borrowed threads could lead to leftover MDC data
+     * to be thread pool safe, we simply clear the MDC after usage
+     *
+     * @param exchange - The HTTP exchange
+     */
+    public void handleAccessLogging(Exchange exchange) {
+        fillMDCMap(exchange);
+        log.info("");
+        MDC.clear();
+    }
+
+    private void fillMDCMap(Exchange exchange) {
+        var contextMap = new HashMap<>(Map.of(
+                "ip", safe(exchange::getRemoteAddrIp),
+                "host", safe(exchange::getOriginalHostHeaderHost),
+                "port", safe(exchange::getOriginalHostHeaderPort),
+                "uri", safe(exchange::getOriginalRequestUri),
+                "proto", safe(() -> exchange.getRequest().getHeader().getFirstValue("x-forwarded-proto").toUpperCase()),
+                "http.version", safe(() -> exchange.getRequest().getVersion()),
+                "http.method", safe(() -> exchange.getRequest().getMethod()),
+                "statusCode", safe(() -> getResponseStatusCode(exchange))
+        ));
+
+        contextMap.putAll(Map.of(
+                "time.req.received.raw", safe(exchange::getTimeReqReceived),
+                "time.req.received.format", convert(safe(exchange::getTimeReqReceived)),
+                "time.req.sent.raw", safe(exchange::getTimeReqSent),
+                "time.req.sent.format", convert(safe(exchange::getTimeReqSent)),
+
+                "time.res.received.raw", safe(exchange::getTimeResReceived),
+                "time.res.received.format", convert(safe(exchange::getTimeResReceived)),
+                "time.res.sent.raw", safe(exchange::getTimeResSent),
+                "time.res.sent.format", convert(safe(exchange::getTimeResSent))
+        ));
+
+        contextMap.putAll(Map.of(
+                "time.diff.received.raw", safe(() -> exchange.getTimeResReceived() - exchange.getTimeReqReceived()),
+                "time.diff.received.format", convert(safe(() -> exchange.getTimeResReceived() - exchange.getTimeReqReceived())),
+
+                "time.diff.sent.raw", safe(() -> exchange.getTimeResSent() - exchange.getTimeReqSent()),
+                "time.diff.sent.format", convert(safe(() -> exchange.getTimeResSent() - exchange.getTimeReqSent()))
+        ));
+
+        if (!excludePayloadSize) {
+            contextMap.put("res.payload.size", safe(() -> {
+                try {
+                    return exchange.getResponse().getBody().getLength();
+                } catch (IOException e) {
+                    return defaultValue;
+                }
+            }));
+            contextMap.put("req.payload.size", safe(() -> {
+                try {
+                    return exchange.getRequest().getBody().getLength();
+                } catch (IOException e) {
+                    return defaultValue;
+                }
+            }));
+        }
+
+        contextMap.putAll(getAdditionalProvidedPattern(exchange, contextMap));
+
+        MDC.setContextMap(contextMap);
+    }
+
+    private String safe(Supplier<Object> access) {
+        return safe(access, defaultValue);
+    }
+
+    private String safe(Supplier<Object> access, String defaultValue) {
+        try {
+            return String.valueOf(access.get());
+        } catch (Exception e) {
+            return defaultValue;
+        }
+    }
+
+    private String getResponseStatusCode(Exchange exchange) {
+        if (exchange.getResponse() == null) {
+            return defaultValue;
+        }
+
+        return String.valueOf(exchange.getResponse().getStatusCode());
+    }
+
+    private Map<String, String> getAdditionalProvidedPattern(Exchange exchange, Map<String, String> existingPatternMap) {
+        if (additionalPatternList.isEmpty()) return Map.of();
+
+        return additionalPatternList.stream()
+                .filter(existingAndNotOverridablePattern(existingPatternMap))
+                .map(additionalPatternToMapEntry(exchange))
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+    }
+
+    private Function<AdditionalPattern, AbstractMap.SimpleEntry<String, String>> additionalPatternToMapEntry(Exchange exchange) {
+        return additionalPattern -> {
+            var value = new SpelExpressionParser()
+                    .parseExpression(additionalPattern.getWithExchange()).getValue(exchange);
+            return new AbstractMap.SimpleEntry<>(additionalPattern.getCreate(), safe(() -> value, additionalPattern.getOrDefaultValue()));
+        };
+    }
+
+    private static Predicate<AdditionalPattern> existingAndNotOverridablePattern(Map<String, String> existingPatternMap) {
+        return additionalPattern ->
+            additionalPattern.isOverride() || !existingPatternMap.containsKey(additionalPattern.getCreate());
+    }
+
+    private String convert(String timestamp) {
+        return dateTimeFormat.format(Long.parseLong(timestamp));
+    }
+
+}

--- a/core/src/main/java/com/predic8/membrane/core/interceptor/log/AdditionalPattern.java
+++ b/core/src/main/java/com/predic8/membrane/core/interceptor/log/AdditionalPattern.java
@@ -1,0 +1,64 @@
+package com.predic8.membrane.core.interceptor.log;
+
+import com.predic8.membrane.annot.MCAttribute;
+import com.predic8.membrane.annot.MCElement;
+import com.predic8.membrane.annot.Required;
+
+@MCElement(name = "additionalPattern", topLevel = false, id = "accessLog-scope")
+public class AdditionalPattern {
+
+    private String create;
+    private String withExchange;
+    private String orDefaultValue = "-";
+    private boolean override = true;
+
+    public String getWithExchange() {
+        return withExchange;
+    }
+
+    /**
+     * @description The SPEL expression to access the property on an Exchange object
+     */
+    @Required
+    @MCAttribute
+    public void setWithExchange(String withExchange) {
+        this.withExchange = withExchange;
+    }
+
+    public String getCreate() {
+        return create;
+    }
+
+    /**
+     * @description The key which can be used to access this value in log4j2.xml like %X{key}
+     */
+    @Required
+    @MCAttribute
+    public void setCreate(String create) {
+        this.create = create;
+    }
+
+    public String getOrDefaultValue() {
+        return orDefaultValue;
+    }
+
+    /**
+     * @description The value if the exchange property is null. Defaults to "-"
+     */
+    @MCAttribute
+    public void setOrDefaultValue(String orDefaultValue) {
+        this.orDefaultValue = orDefaultValue;
+    }
+
+    public boolean isOverride() {
+        return override;
+    }
+
+    /**
+     * @description If it should override existing patterns, defaults to true
+     */
+    @MCAttribute
+    public void setOverride(boolean override) {
+        this.override = override;
+    }
+}

--- a/distribution/conf/log4j2.xml
+++ b/distribution/conf/log4j2.xml
@@ -2,7 +2,7 @@
 <Configuration>
     <Appenders>
         <Console name="ACCESS" target="SYSTEM_OUT">
-            <PatternLayout pattern="%X{ip} [%X{time}] &quot;%X{http.method} %X{uri} %X{proto}/%X{http.version}&quot; %X{statusCode} %X{payload.size} %X{host}%n" />
+            <PatternLayout pattern="%X{ip} [%X{time.req.received.format}] &quot;%X{http.method} %X{uri} %X{proto}/%X{http.version}&quot; %X{statusCode} %X{req.payload.size}%n" />
         </Console>
         <Console name="STDOUT" target="SYSTEM_OUT">
             <PatternLayout pattern="%d{ABSOLUTE} %5p %tid %tn %c{1}:%L - %m%n" />

--- a/distribution/conf/log4j2.xml
+++ b/distribution/conf/log4j2.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Configuration>
     <Appenders>
+        <Console name="ACCESS" target="SYSTEM_OUT">
+            <PatternLayout pattern="%X{ip} [%X{time}] &quot;%X{http.method} %X{proto}/%X{http.version}&quot; %X{statusCode} %X{payload.size}%n" />
+        </Console>
         <Console name="STDOUT" target="SYSTEM_OUT">
             <PatternLayout pattern="%d{ABSOLUTE} %5p %tid %tn %c{1}:%L - %m%n" />
         </Console>
@@ -15,6 +18,9 @@
     <Loggers>
         <Logger name="com.predic8.membrane.core.openapi" level="debug">
             <AppenderRef ref="FILE" />
+        </Logger>
+        <Logger name="com.predic8.membrane.core.interceptor.log" level="info" additivity="false">
+            <AppenderRef ref="ACCESS" />
         </Logger>
         <Logger name="com.predic8" level="info">
             <AppenderRef ref="FILE" />

--- a/distribution/conf/log4j2.xml
+++ b/distribution/conf/log4j2.xml
@@ -2,7 +2,7 @@
 <Configuration>
     <Appenders>
         <Console name="ACCESS" target="SYSTEM_OUT">
-            <PatternLayout pattern="%X{ip} [%X{time}] &quot;%X{http.method} %X{uri} %X{proto}/%X{http.version}&quot; %X{statusCode} %X{payload.size}%n" />
+            <PatternLayout pattern="%X{ip} [%X{time}] &quot;%X{http.method} %X{uri} %X{proto}/%X{http.version}&quot; %X{statusCode} %X{payload.size} %X{host}%n" />
         </Console>
         <Console name="STDOUT" target="SYSTEM_OUT">
             <PatternLayout pattern="%d{ABSOLUTE} %5p %tid %tn %c{1}:%L - %m%n" />

--- a/distribution/conf/log4j2.xml
+++ b/distribution/conf/log4j2.xml
@@ -2,7 +2,7 @@
 <Configuration>
     <Appenders>
         <Console name="ACCESS" target="SYSTEM_OUT">
-            <PatternLayout pattern="%X{ip} [%X{time}] &quot;%X{http.method} %X{proto}/%X{http.version}&quot; %X{statusCode} %X{payload.size}%n" />
+            <PatternLayout pattern="%X{ip} [%X{time}] &quot;%X{http.method} %X{uri} %X{proto}/%X{http.version}&quot; %X{statusCode} %X{payload.size}%n" />
         </Console>
         <Console name="STDOUT" target="SYSTEM_OUT">
             <PatternLayout pattern="%d{ABSOLUTE} %5p %tid %tn %c{1}:%L - %m%n" />

--- a/distribution/conf/proxies.xml
+++ b/distribution/conf/proxies.xml
@@ -7,7 +7,12 @@
     <router>
 
         <api port="2000">
-            <target host="api.predic8.de"/>
+            <accessLog>
+                <additionalPattern create="port" withExchange="originalHostHeaderPort" override="false" />
+                <additionalPattern create="response.status" withExchange="response?.statusCode" orDefaultValue="NOT" />
+                <additionalPattern create="host" withExchange="request.header.getFirstValue('host')" orDefaultValue="NIRVANA" />
+            </accessLog>
+            <target url="https://api.predic8.de"/>
         </api>
 
     </router>

--- a/distribution/examples/logging/access/README.md
+++ b/distribution/examples/logging/access/README.md
@@ -1,0 +1,37 @@
+# Access Log Interceptor
+
+The access log interceptor provides a set of common and useful exchange properties to use in a `log4j2.xml` pattern layout configuration.
+The default implementation provides a [Apache Common Log](https://httpd.apache.org/docs/trunk/logs.html#common) pattern.
+
+You can provide optional `<additionalPattern>` to extend or override the default configuration.
+
+## Configuration
+
+You can configure the following attibutes
+
+### AccessLogInterceptor
+
+The base interceptor
+
+| Attribute | Use-Case | Default |
+|-----------|----------|---------|
+| defaultValue | if the value is not existent we log this character in place | - |
+| dateTimePattern | format timestamps according to the provided pattern | dd/MM/yyyy:HH:mm:ss Z |
+| excludePayloadSize | reading the payload size will disable streaming | false |
+
+### AdditionalPattern
+
+Provide optional pattern to the `AccessLogInterceptor`
+
+| Key    | Value | Default | Required |
+|--------|-------|---------|----------|
+| create | the access key for the pattern layout | | x |
+| withExchange | [SpEL](https://docs.spring.io/spring-framework/docs/3.2.x/spring-framework-reference/html/expressions.html) expression to access the Exchange object | | x |
+| orDefaultValue | provide a default value if the value could not be retrieved from the Exchange | - | |
+| override | toggle if the given access key is able to override existing access keys | true | |
+
+
+
+
+
+

--- a/distribution/examples/logging/access/log4j2.xml
+++ b/distribution/examples/logging/access/log4j2.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration>
+    <Appenders>
+        <Console name="ACCESS" target="SYSTEM_OUT">
+            <PatternLayout pattern="%X{ip} [%X{time.req.received.format}] &quot;%X{http.method} %X{uri} %X{proto}/%X{http.version}&quot; %X{statusCode} %X{req.payload.size}%n" />
+        </Console>
+    </Appenders>
+    <Loggers>
+        <Logger name="com.predic8.membrane.core.interceptor.log" level="info" additivity="false">
+            <AppenderRef ref="ACCESS" />
+        </Logger>
+    </Loggers>
+</Configuration>

--- a/distribution/examples/logging/access/proxies.xml
+++ b/distribution/examples/logging/access/proxies.xml
@@ -1,0 +1,19 @@
+<spring:beans xmlns="http://membrane-soa.org/proxies/1/"
+              xmlns:spring="http://www.springframework.org/schema/beans"
+              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+					    http://membrane-soa.org/proxies/1/ http://membrane-soa.org/schemas/proxies-1.xsd">
+
+    <router>
+
+        <api port="2000">
+            <accessLog>
+                <additionalPattern create="port" withExchange="originalHostHeaderPort" override="false" />
+                <additionalPattern create="response.statusCode" withExchange="response?.statusCode" orDefaultValue="???" />
+            </accessLog>
+            <target host="www.predic8.de" port="80" />
+        </api>
+
+    </router>
+
+</spring:beans>

--- a/distribution/examples/logging/access/service-proxy.bat
+++ b/distribution/examples/logging/access/service-proxy.bat
@@ -1,0 +1,18 @@
+@echo off
+if not "%MEMBRANE_HOME%" == "" goto homeSet
+set "MEMBRANE_HOME=%cd%\..\..\.."
+echo "%MEMBRANE_HOME%"
+if exist "%MEMBRANE_HOME%\service-proxy.bat" goto homeOk
+
+:homeSet
+if exist "%MEMBRANE_HOME%\service-proxy.bat" goto homeOk
+echo Please set the MEMBRANE_HOME environment variable to point to
+echo the directory where you have extracted the Membrane software.
+exit
+
+:homeOk
+set "CLASSPATH=%MEMBRANE_HOME%"
+set "CLASSPATH=%MEMBRANE_HOME%/conf"
+set "CLASSPATH=%CLASSPATH%;%MEMBRANE_HOME%/starter.jar"
+echo Membrane Router running...
+java  -classpath "%CLASSPATH%" com.predic8.membrane.core.Starter -c proxies.xml

--- a/distribution/examples/logging/access/service-proxy.sh
+++ b/distribution/examples/logging/access/service-proxy.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+homeSet() {
+ echo "MEMBRANE_HOME variable is now set"
+ CLASSPATH="$MEMBRANE_HOME/conf"
+ CLASSPATH="$CLASSPATH:$MEMBRANE_HOME/starter.jar"
+ export CLASSPATH
+ echo Membrane Router running...
+ java  -classpath "$CLASSPATH" com.predic8.membrane.core.Starter -c proxies.xml
+ 
+}
+
+terminate() {
+	echo "Starting of Membrane Router failed."
+	echo "Please execute this script from the appropriate subfolder of MEMBRANE_HOME/examples/"
+	
+}
+
+homeNotSet() {
+  echo "MEMBRANE_HOME variable is not set"
+
+  if [ -f  "`pwd`/../../../starter.jar" ]
+    then 
+    	export MEMBRANE_HOME="`pwd`/../../.."
+    	homeSet	
+    else
+    	terminate    
+  fi 
+}
+
+
+if  [ "$MEMBRANE_HOME" ]  
+	then homeSet
+	else homeNotSet
+fi
+


### PR DESCRIPTION
Current `log4j2.xml` configuration would enable logs like:

`127.0.0.1 [07/09/2023:17:15:20 +0200] "GET / HTTP/1.1" 200 13187`

It could be configured like this:

```xml
<api port="2000">
    <accessLog>
        <additionalPattern create="port" withExchange="originalHostHeaderPort" override="false" />
        <additionalPattern create="response.status" withExchange="response?.statusCode" orDefaultValue="NOT" />
    </accessLog>
    <target host="www.predic8.de" port="80" />
</api>
```

where `additionalPattern` is optional and provides some configurability like the `accessLog`.

I'd like to discuss:

1. if there could be a use-case for request logging, if not I could simplify the MDC-Map-creation. It was first designed with request logging in mind and might be messier than needed.
2. `exchange.getResponse().getBody().getLength()` and some other methods for content payload size are commented with this warning `Warning: Calling this method will trigger reading the body from the client, disabling "streaming".`. Is this a Issue? Is there a good way around?
3. Should we log authentication credentials like email/names or something to identify the user triggering the call?

